### PR TITLE
Add stoi guard

### DIFF
--- a/openifs.cpp
+++ b/openifs.cpp
@@ -619,7 +619,7 @@ int main(int argc, char** argv) {
 	
 
     // Start the OpenIFS job
-    std::string strCmd = slot_path + std::string("/./master.exe");
+    std::string strCmd = slot_path + std::string("/oifs_43r3_model.exe");
     handleProcess = launch_process(slot_path,strCmd.c_str(),exptid.c_str(),app_name);
     if (handleProcess > 0) process_status = 0;
 

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1465,7 +1465,7 @@ bool check_stoi(std::string& cin) {
     //  n.b. still need to check step <= max_step
     try {
         step = std::stoi(cin);
-        cerr << "step converted is : " << step << "\n";
+        //cerr << "step converted is : " << step << "\n";
         return true;
     }
     catch (const std::invalid_argument &excep) {

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1439,3 +1439,33 @@ std::string get_second_part(string last_iter, string exptid) {
 
    return second_part;
 }
+
+
+bool check_stoi(std::string& cin) {
+    //  check input string is convertable to an integer by checking for any letters
+    //  nb. stoi() will convert leading digits if alphanumeric but we know step must be all digits.
+    //  Glenn Carver
+
+    int step;
+
+    if (std::any_of(cin.begin(), cin.end(), ::isalpha)) {
+        cerr << "Invalid characters in stoi string: " << cin << "\n";
+        return false;
+    }
+
+    //  check stoi standard exceptions
+    //  n.b. still need to check step <= max_step
+    try {
+        step = std::stoi(cin);
+        cerr << "step converted is : " << step << "\n";
+        return true;
+    }
+    catch (const std::invalid_argument &excep) {
+        cerr << "Invalid input argument for stoi : " << excep.what() << "\n";
+        return false;
+    }
+    catch (const std::out_of_range &excep) {
+        cerr << "Out of range value for stoi : " << excep.what() << "\n";
+        return false;
+    }
+}

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -43,6 +43,7 @@ bool file_exists(const std::string &str);
 double cpu_time(long);
 double model_frac_done(double,double,int);
 std::string get_second_part(const std::string, const std::string);
+bool check_stoi(std::string& cin);
 
 using namespace std;
 using namespace std::chrono;
@@ -618,7 +619,7 @@ int main(int argc, char** argv) {
 	
 
     // Start the OpenIFS job
-    std::string strCmd = slot_path + std::string("/./openifs_43r3.exe");
+    std::string strCmd = slot_path + std::string("/./master.exe");
     handleProcess = launch_process(slot_path,strCmd.c_str(),exptid.c_str(),app_name);
     if (handleProcess > 0) process_status = 0;
 
@@ -665,6 +666,12 @@ int main(int argc, char** argv) {
           // to the files for that iteration, those files can now be moved and uploaded
           //fprintf(stderr,"iter: %i\n",std::stoi(iter));
           //fprintf(stderr,"last_iter: %i\n",std::stoi(last_iter));
+
+          // GC: Check for garbage in the retrieved string first, otherwise stoi will kill this process.
+          if (!check_stoi(iter)) {
+            fprintf(stderr,"Unable to update iter, resetting to last_iter.\n");
+            iter = last_iter;
+          }
 
           if (std::stoi(iter) != std::stoi(last_iter)) {
              // Construct file name of the ICM result file
@@ -1444,6 +1451,7 @@ std::string get_second_part(string last_iter, string exptid) {
 bool check_stoi(std::string& cin) {
     //  check input string is convertable to an integer by checking for any letters
     //  nb. stoi() will convert leading digits if alphanumeric but we know step must be all digits.
+    //  Returns true on success, false if non-numeric data in input string.
     //  Glenn Carver
 
     int step;


### PR DESCRIPTION
Andy,

This fixes wrapper process dying in case of an stoi failure when reading 'iter' from the ifs.stat file. Adds new function and guard code before the conversion of iter.  In the case of bad iter values, it is reset to 'last_iter.  

Could also be used in other places in the code where an stoi is about to be performed on, possibly corrupt, data is read from a file.

Have tested this with one of Clement's tasks using boinc running standalone. Tested by suspending master.exe process and manually adding corrupt line to ifs.stat. Wrapper correctly caught it and carried on.

Best,  Glenn