### PR TITLE
correct if statement with trickle_upload_count

### DIFF
--- a/openifs.cpp
+++ b/openifs.cpp
@@ -810,7 +810,7 @@ int main(int argc, char** argv) {
                       }
 		      
 		      trickle_upload_count++;
-		      if (trickle_upload_count = 10) {   
+		      if (trickle_upload_count == 10) {
                         // Produce trickle
                         process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
 		        trickle_upload_count = 0;
@@ -848,7 +848,7 @@ int main(int argc, char** argv) {
                    last_upload = current_iter;
 		
                    trickle_upload_count++;
-		   if (trickle_upload_count = 10) {   
+		   if (trickle_upload_count == 10) {
                       // Produce trickle
                       process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
 		      trickle_upload_count = 0;


### PR DESCRIPTION
Andy, code had this:

		      trickle_upload_count++;
		      if (trickle_upload_count = 10) {     <<<<<<<<<<  should be == ?
                        // Produce trickle
                        process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);

I believe this was intended to be  : if (trickle_upload_count == 10), rather than an assignment of trickle_upload_count. Occurs twice.