### PR TITLE
Combined 'log/diagnostics improvements', 'reduce I/O' and 'improved child control' branches

### DIFF
--- a/openifs.cpp
+++ b/openifs.cpp
@@ -507,7 +507,7 @@ int main(int argc, char** argv) {
     pathvar = getenv("EC_MEMINFO");
     //fprintf(stderr, "The EC_MEMINFO environment variable is: %s\n", pathvar);
 
-    // Disable Heap memory stats at end of run; do not work for CPDN version of OpenIFS
+    // Disable Heap memory stats at end of run; does not work for CPDN version of OpenIFS
     std::string EC_PROFILE_HEAP("EC_PROFILE_HEAP=0");
     if (putenv((char *)EC_PROFILE_HEAP.c_str())) {
        fprintf(stderr,"..Setting the EC_PROFILE_HEAP environment variable failed\n");
@@ -515,6 +515,15 @@ int main(int argc, char** argv) {
     }
     pathvar = getenv("EC_PROFILE_HEAP");
     //fprintf(stderr, "The EC_PROFILE_HEAP environment variable is: %s\n",pathvar);
+
+    // Disable all memory stats at end of run; does not work for CPDN version of OpenIFS
+    std::string EC_PROFILE_MEM("EC_PROFILE_MEM=0");
+    if (putenv((char *)EC_PROFILE_MEM.c_str())) {
+       fprintf(stderr,"..Setting the EC_PROFILE_MEM environment variable failed\n");
+       return 1;
+    }
+    pathvar = getenv("EC_PROFILE_MEM");
+    //fprintf(stderr, "The EC_PROFILE_MEM environment variable is: %s\n",pathvar);
 
     // Set the OMP_STACKSIZE environmental variable, OpenIFS needs more stack memory per process
     std::string OMP_STACK_var("OMP_STACKSIZE=128M");

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -948,10 +948,12 @@ int main(int argc, char** argv) {
     }
 
 
-    // Time delay to ensure final ICM are complete
-    sleep_until(system_clock::now() + seconds(60));	
+    // Time delay to ensure model files are all flushed to disk
+    sleep_until(system_clock::now() + seconds(60));
 
-	
+    // Print content of key model files to help with diagnosing problems
+    print_last_lines("NODE.001_01", 100);    //  main model output log	
+
     // Check whether model completed successfully
     if(file_exists(slot_path + std::string("/ifs.stat"))) {
        if(!(ifs_stat_file.is_open())) {
@@ -974,8 +976,12 @@ int main(int argc, char** argv) {
           }
        }
        if (last_line!="CNT0") {
-          fprintf(stderr,"..Failed, model did not complete successfully\n");
-          return 1;
+         // print extra files to help diagnose fail
+         print_last_lines("rcf",11);              // openifs restart control
+         print_last_lines("waminfo",17);          // wave model restart control
+         print_last_lines(progress_file,8);
+         fprintf(stderr,"..Failed, model did not complete successfully\n");
+         return 1;
        }
     }
     // ifs.stat has not been produced, then model did not start

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1187,34 +1187,30 @@ const char* strip_path(const char* path) {
 
 
 int check_child_status(long handleProcess, int process_status) {
-    int stat,pid;
+    int stat;
+    //fprintf(stderr,"waitpid: %i\n",waitpid(handleProcess,0,WNOHANG));
 
-    // Check whether child processed has exited 
-    // waitpid will return process id of zombie (finished) process; zero if still running
-    if ( (pid=waitpid(handleProcess,&stat,WNOHANG)) > 0 ) {
+    // Check whether child processed has exited
+    if (waitpid(handleProcess,&stat,WNOHANG)==-1) {
        process_status = 1;
-       // Child exited normally but model might still have failed
+       // Child exited normally
        if (WIFEXITED(stat)) {
           process_status = 1;
-          cerr << "..The child process terminated with status: " << WEXITSTATUS(stat) << endl;
+          fprintf(stderr,"The child process terminated with status: %d\n",WEXITSTATUS(stat));
+          fflush(stderr);
        }
-       // Child process has exited due to signal that was not caught
-       // n.b. OpenIFS has its own signal handler so unlikely to come here.
+       // Child process has exited
        else if (WIFSIGNALED(stat)) {
-          process_status = 3;  
-          cerr << "..The child process has been killed with signal: " << WTERMSIG(stat) << endl;
+          process_status = 3;
+          fprintf(stderr,"..The child process has been killed with signal: %d\n",WTERMSIG(stat));
+          fflush(stderr);
        }
        // Child is stopped
        else if (WIFSTOPPED(stat)) {
           process_status = 4;
-          cerr << "..The child process has stopped with signal: " << WSTOPSIG(stat) << endl;
+          fprintf(stderr,"..The child process has stopped with signal: %d\n",WSTOPSIG(stat));
+          fflush(stderr);
        }
-    }
-    else if ( pid == -1) {
-      // should not get here, it means the child could not be found
-      process_status = 5;
-      cerr << "Unable to retrieve status of child process " << endl;
-      perror("waitpid() error");
     }
     return process_status;
 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -668,7 +668,6 @@ int main(int argc, char** argv) {
     // process_status = 2 stopped with quit request from BOINC
     // process_status = 3 stopped with child process being killed
     // process_status = 4 stopped with child process being stopped
-    // process_status = 5 child process not found by waitpid()
 
 
     // Main loop:	

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -444,7 +444,7 @@ int main(int argc, char** argv) {
     // Set the environmental variables:
     // Set the OIFS_DUMMY_ACTION environmental variable, this controls what OpenIFS does if it goes into a dummy subroutine
     // Possible values are: 'quiet', 'verbose' or 'abort'
-    std::string OIFS_var = std::string("OIFS_DUMMY_ACTION=abort");
+    std::string OIFS_var("OIFS_DUMMY_ACTION=abort");
     if (putenv((char *)OIFS_var.c_str())) {
       fprintf(stderr,"..Setting the OIFS_DUMMY_ACTION environmental variable failed\n");
       return 1;
@@ -462,7 +462,7 @@ int main(int argc, char** argv) {
     //fprintf(stderr,"The OMP_NUM_THREADS environmental variable is: %s\n",pathvar);
 
     // Set the OMP_SCHEDULE environmental variable, this enforces static thread scheduling
-    std::string OMP_SCHED_var = std::string("OMP_SCHEDULE=STATIC");
+    std::string OMP_SCHED_var("OMP_SCHEDULE=STATIC");
     if (putenv((char *)OMP_SCHED_var.c_str())) {
       fprintf(stderr,"..Setting the OMP_SCHEDULE environmental variable failed\n");
       return 1;
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     //fprintf(stderr,"The OMP_SCHEDULE environmental variable is: %s\n",pathvar);
 
     // Set the DR_HOOK environmental variable, this controls the tracing facility in OpenIFS, off=0 and on=1
-    std::string DR_HOOK_var = std::string("DR_HOOK=1");
+    std::string DR_HOOK_var("DR_HOOK=1");
     if (putenv((char *)DR_HOOK_var.c_str())) {
       fprintf(stderr,"..Setting the DR_HOOK environmental variable failed\n");
       return 1;
@@ -480,7 +480,7 @@ int main(int argc, char** argv) {
     //fprintf(stderr,"The DR_HOOK environmental variable is: %s\n",pathvar);
 
     // Set the DR_HOOK_HEAPCHECK environmental variable, this ensures the heap size statistics are reported
-    std::string DR_HOOK_HEAP_var = std::string("DR_HOOK_HEAPCHECK=no");
+    std::string DR_HOOK_HEAP_var("DR_HOOK_HEAPCHECK=no");
     if (putenv((char *)DR_HOOK_HEAP_var.c_str())) {
       fprintf(stderr,"..Setting the DR_HOOK_HEAPCHECK environmental variable failed\n");
       return 1;
@@ -489,7 +489,7 @@ int main(int argc, char** argv) {
     //fprintf(stderr,"The DR_HOOK_HEAPCHECK environmental variable is: %s\n",pathvar);
 
     // Set the DR_HOOK_STACKCHECK environmental variable, this ensures the stack size statistics are reported
-    std::string DR_HOOK_STACK_var = std::string("DR_HOOK_STACKCHECK=no");
+    std::string DR_HOOK_STACK_var("DR_HOOK_STACKCHECK=no");
     if (putenv((char *)DR_HOOK_STACK_var.c_str())) {
       fprintf(stderr,"..Setting the DR_HOOK_STACKCHECK environmental variable failed\n");
       return 1;
@@ -499,7 +499,7 @@ int main(int argc, char** argv) {
 	
     // Set the EC_MEMINFO environment variable, only applies to OpenIFS 43r3.
     // Disable EC_MEMINFO to remove the useless EC_MEMINFO messages to the stdout file to reduce filesize.
-    std::string EC_MEMINFO = std::string("EC_MEMINFO=0");
+    std::string EC_MEMINFO("EC_MEMINFO=0");
     if (putenv((char *)EC_MEMINFO.c_str())) {
        fprintf(stderr,"..Setting the EC_MEMINFO environment variable failed\n");
        return 1;
@@ -517,7 +517,7 @@ int main(int argc, char** argv) {
     //fprintf(stderr, "The EC_PROFILE_HEAP environment variable is: %s\n",pathvar);
 
     // Set the OMP_STACKSIZE environmental variable, OpenIFS needs more stack memory per process
-    std::string OMP_STACK_var = std::string("OMP_STACKSIZE=128M");
+    std::string OMP_STACK_var("OMP_STACKSIZE=128M");
     if (putenv((char *)OMP_STACK_var.c_str())) {
       fprintf(stderr,"..Setting the OMP_STACKSIZE environmental variable failed\n");
       return 1;

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -951,7 +951,7 @@ int main(int argc, char** argv) {
     sleep_until(system_clock::now() + seconds(60));
 
     // Print content of key model files to help with diagnosing problems
-    print_last_lines("NODE.001_01", 100);    //  main model output log	
+    print_last_lines("NODE.001_01", 150);    //  main model output log	
 
     // Check whether model completed successfully
     if(file_exists(slot_path + std::string("/ifs.stat"))) {

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -980,6 +980,7 @@ int main(int argc, char** argv) {
          print_last_lines("waminfo",17);          // wave model restart control
          print_last_lines(progress_file,8);
          fprintf(stderr,"..Failed, model did not complete successfully\n");
+         fflush(stderr);
          return 1;
        }
     }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1549,7 +1549,7 @@ int print_last_lines(string filename, int inlines) {
    //          > 0  : no. of lines in file (may be less than nlines)
    //  Glenn
 
-   int     maxlines = 100;
+   int     maxlines = 200;
    int     count = 0;
    int     start, end;
    string  lines[maxlines];

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1053,6 +1053,8 @@ int main(int argc, char** argv) {
     zfl.push_back(node_file);
     std::string ifsstat_file = slot_path + std::string("/ifs.stat");
     zfl.push_back(ifsstat_file);
+    cerr << "Adding to the zip: " << node_file << '\n';
+    cerr << "Adding to the zip: " << ifsstat_file << '\n';
 
     // Read the remaining list of files from the slots directory and add the matching files to the list of files for the zip
     dirp = opendir(temp_path.c_str());

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -668,6 +668,7 @@ int main(int argc, char** argv) {
     // process_status = 2 stopped with quit request from BOINC
     // process_status = 3 stopped with child process being killed
     // process_status = 4 stopped with child process being stopped
+    // process_status = 5 child process not found by waitpid()
 
 
     // Main loop:	
@@ -1180,30 +1181,34 @@ const char* strip_path(const char* path) {
 
 
 int check_child_status(long handleProcess, int process_status) {
-    int stat;
-    //fprintf(stderr,"waitpid: %i\n",waitpid(handleProcess,0,WNOHANG));
+    int stat,pid;
 
-    // Check whether child processed has exited
-    if (waitpid(handleProcess,&stat,WNOHANG)==-1) {
+    // Check whether child processed has exited 
+    // waitpid will return process id of zombie (finished) process; zero if still running
+    if ( (pid=waitpid(handleProcess,&stat,WNOHANG)) > 0 ) {
        process_status = 1;
-       // Child exited normally
+       // Child exited normally but model might still have failed
        if (WIFEXITED(stat)) {
-	  process_status = 1;
-          fprintf(stderr,"The child process terminated with status: %d\n",WEXITSTATUS(stat));
-          fflush(stderr);
+          process_status = 1;
+          cerr << "..The child process terminated with status: " << WEXITSTATUS(stat) << endl;
        }
-       // Child process has exited
+       // Child process has exited due to signal that was not caught
+       // n.b. OpenIFS has its own signal handler so unlikely to come here.
        else if (WIFSIGNALED(stat)) {
-	  process_status = 3;  
-          fprintf(stderr,"..The child process has been killed with signal: %d\n",WTERMSIG(stat));
-          fflush(stderr);
+          process_status = 3;  
+          cerr << "..The child process has been killed with signal: " << WTERMSIG(stat) << endl;
        }
        // Child is stopped
        else if (WIFSTOPPED(stat)) {
-	  process_status = 4;
-          fprintf(stderr,"..The child process has stopped with signal: %d\n",WSTOPSIG(stat));
-          fflush(stderr);
+          process_status = 4;
+          cerr << "..The child process has stopped with signal: " << WSTOPSIG(stat) << endl;
        }
+    }
+    else if ( pid == -1) {
+      // should not get here, it means the child could not be found
+      process_status = 5;
+      cerr << "Unable to retrieve status of child process " << endl;
+      perror("waitpid() error");
     }
     return process_status;
 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -507,6 +507,15 @@ int main(int argc, char** argv) {
     pathvar = getenv("EC_MEMINFO");
     //fprintf(stderr, "The EC_MEMINFO environment variable is: %s\n, pathvar);
 
+    // Disable Heap memory stats at end of run; do not work for CPDN version of OpenIFS
+    std::string EC_PROFILE_HEAP("EC_PROFILE_HEAP=0");
+    if (putenv((char *)EC_PROFILE_HEAP.c_str())) {
+       fprintf(stderr,"..Setting the EC_PROFILE_HEAP environment variable failed\n");
+       return 1;
+    }
+    pathvar = getenv("EC_PROFILE_HEAP");
+    //fprintf(stderr, "The EC_PROFILE_HEAP environment variable is: %s\n",pathvar);
+
     // Set the OMP_STACKSIZE environmental variable, OpenIFS needs more stack memory per process
     std::string OMP_STACK_var = std::string("OMP_STACKSIZE=128M");
     if (putenv((char *)OMP_STACK_var.c_str())) {

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -505,7 +505,7 @@ int main(int argc, char** argv) {
        return 1;
     }
     pathvar = getenv("EC_MEMINFO");
-    //fprintf(stderr, "The EC_MEMINFO environment variable is: %s\n, pathvar);
+    //fprintf(stderr, "The EC_MEMINFO environment variable is: %s\n", pathvar);
 
     // Disable Heap memory stats at end of run; do not work for CPDN version of OpenIFS
     std::string EC_PROFILE_HEAP("EC_PROFILE_HEAP=0");

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -49,6 +49,7 @@ double cpu_time(long);
 double model_frac_done(double,double,int);
 std::string get_second_part(const std::string, const std::string);
 bool check_stoi(std::string& cin);
+int  print_last_lines(std::string filename, int nlines);
 
 using namespace std;
 using namespace std::chrono;
@@ -1533,4 +1534,36 @@ bool check_stoi(std::string& cin) {
         cerr << "Out of range value for stoi : " << excep.what() << "\n";
         return false;
     }
+}
+
+int print_last_lines(string filename, int inlines) {
+   // Opens a file if exists and uses circular buffer to read & print last 'nlines' of file to stderr.
+   // Returns: zero : either can't open file or file is empty
+   //          > 0  : no. of lines in file (may be less than nlines)
+   //  Glenn
+
+   int     maxlines = 100;
+   int     count = 0;
+   int     start, end;
+   string  lines[maxlines];
+   ifstream filein(filename);
+
+   if ( filein.is_open() ) {
+      while ( getline(filein, lines[count%maxlines]) )
+         count++;
+   }
+
+   if ( count > 0 ) {
+      // find the oldest lines first in the buffer, will not be at start if count > maxlines
+      start = count > maxlines ? (count%maxlines) : 0;
+      end   = min(maxlines,count);
+
+      cerr << ">>> Printing last " << end << " lines from file: " << filename << '\n';
+      for ( int i=0; i<end; i++ ) {
+         cerr << lines[ (start+i)%maxlines ] << '\n';
+      }
+      cerr << "------------------------------------------------" << '\n';
+   }
+
+   return count;
 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1545,13 +1545,12 @@ bool check_stoi(std::string& cin) {
     }
 }
 
-int print_last_lines(string filename, int inlines) {
-   // Opens a file if exists and uses circular buffer to read & print last 'nlines' of file to stderr.
+int print_last_lines(string filename, int maxlines) {
+   // Opens a file if exists and uses circular buffer to read & print last lines of file to stderr.
    // Returns: zero : either can't open file or file is empty
-   //          > 0  : no. of lines in file (may be less than nlines)
+   //          > 0  : no. of lines in file (may be less than maxlines)
    //  Glenn
 
-   int     maxlines = 200;
    int     count = 0;
    int     start, end;
    string  lines[maxlines];

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -939,28 +939,12 @@ int main(int argc, char** argv) {
     sleep_until(system_clock::now() + seconds(60));	
 
 	
-    // Check whether model completed successfully
+    // To check whether model completed successfully, look for 'CNT0' in 3rd column of ifs.stat
+    // This will always be the last line of a successful model forecast.
     if(file_exists(slot_path + std::string("/ifs.stat"))) {
-       if(!(ifs_stat_file.is_open())) {
-          //fprintf(stderr,"Opening ifs.stat file\n");
-          ifs_stat_file.open(slot_path + std::string("/ifs.stat"));
-       }
-
-       // Read last line from ifs.stat file
-       while(std::getline(ifs_stat_file, ifs_line)) {  //get 1 row as a string
-          //fprintf(stderr,"Reading ifs.stat file\n");
-
-          std::istringstream iss2(ifs_line);  //put line into stringstream
-          int ifs_word_count=0;
-          // Read fourth column from file
-          while(iss2 >> ifs_word) {  //read word by word
-             ifs_word_count++;
-             if (ifs_word_count==3) last_line = ifs_word;
-             //fprintf(stderr,"count: %i\n",ifs_word_count);
-             //fprintf(stderr,"last_line: %s\n",last_line.c_str());
-          }
-       }
-       if (last_line!="CNT0") {
+       ifs_word="";
+       oifs_parse_ifsstat(ifs_stat_file,ifs_word,3);
+       if (ifs_word!="CNT0") {
           fprintf(stderr,"..Failed, model did not complete successfully\n");
           return 1;
        }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1537,7 +1537,7 @@ bool oifs_parse_ifsstat(std::ifstream& ifs_stat, std::string& stat_column, int i
 
     ifs_stat.seekg(p);
     while ( std::getline(ifs_stat, logline) ) {
-        cerr << "oifs_parse_ifsstat: " << logline << endl;
+        //cerr << "oifs_parse_ifsstat: " << logline << endl;
 
         //  split input, get token specified by 'column' unless file is corrupted
         tokens.str(logline);
@@ -1559,7 +1559,7 @@ bool oifs_parse_ifsstat(std::ifstream& ifs_stat, std::string& stat_column, int i
       return false;
     } else {
       stat_column = statstr;
-      cerr << "oifs_parse_ifsstat: parsed string  = " << stat_column << " index " << index << '\n';
+      //cerr << "oifs_parse_ifsstat: parsed string  = " << stat_column << " index " << index << '\n';
       return true;
     }
 }


### PR DESCRIPTION
Andy,

Due to conflicts with the branches that were separately developed, I've merged them into a single branch for the pull request to save you the conflicts.  This combined branch has been testing with Clement's setup; both with a normal and a restarted run, fully from model start to end.

The list of changes are:
  -- added 2 new env vars to reduce the profile output written by OpenIFS.
  -- added new code to output end of log files to help diagnose problems.
  -- check_child now correctly processes the return of waitpid.
  -- added new code to reduce repeatedly reading ifs.stat & instead keep file open & advance fileptr
  -- added new fn to check iter is within valid bounds of the timestep
  -- removed double creation of string objects in env var.

All tested and ready for a devtest.

Cheers,  Glenn