### PR TITLE
Fix memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,31 @@
 #
-#  Makefile to generate the openifs wrapper
+#  Makefile to generate the openifs wrapper.
 #
-#    A standalone version of the control code links against
-#    boinc client libraries with 'standalone' set in api/boinc_api.cpp
+#  Creates both production & debug versions.
 #
 #       Glenn 
 
 VERSION = 1.08
 TARGET  = openifs_$(VERSION)_x86_64-pc-linux-gnu
-STANDALONE = openifs_$(VERSION)_x86_64-pc-linux-gnu-standalone
+DEBUG   = openifs_$(VERSION)_x86_64-pc-linux-gnu-debug
 SRC     = openifs.cpp
 
 CC       = g++
 CFLAGS   = -g -static -pthread -std=c++17 -Wall
-CDEBUG   = -ggdb3
+# Address Sanitizer (ASan) can't use -static
+CDEBUG   = -fsanitize=address -ggdb3 -pthread -std=c++17 -Wall
 INCLUDES    = -I../boinc-install/include
-INCLUDES_ST = -I../boinc-install-standalone/include
 LIBDIR    = -L../boinc-install/lib
-LIBDIR_ST = -L../boinc-install-standalone/lib
 LIBS      = -lboinc_api -lboinc_zip -lboinc
 
 
-all: $(TARGET) $(STANDALONE)
+all: $(TARGET) $(DEBUG)
 
 $(TARGET): $(SRC)
 	$(CC) $(SRC) $(CFLAGS) $(INCLUDES) $(LIBDIR) $(LIBS) -o $(TARGET)
 
-$(STANDALONE): $(SRC)
-	$(CC) $(SRC) $(CFLAGS) $(CDEBUG) $(INCLUDES_ST) $(LIBDIR_ST) $(LIBS) -o $(STANDALONE)
-                
+$(DEBUG): $(SRC)
+	$(CC) $(SRC) $(CDEBUG) $(INCLUDES) $(LIBDIR) $(LIBS) -o $(DEBUG)
+
 clean:
-	$(RM) *.o $(TARGET) $(STANDALONE)
+	$(RM) *.o $(TARGET) $(DEBUG)

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1052,9 +1052,9 @@ int main(int argc, char** argv) {
     // Read the remaining list of files from the slots directory and add the matching files to the list of files for the zip
     dirp = opendir(temp_path.c_str());
     if (dirp) {
+        regcomp(&regex,"\\+",0);
         while ((dir = readdir(dirp)) != NULL) {
           //fprintf(stderr,"In temp folder: %s\n",dir->d_name);
-          regcomp(&regex,"\\+",0);
 
           if (!regexec(&regex,dir->d_name,(size_t) 0,NULL,0)) {
             zfl.push_back(temp_path+std::string("/")+dir->d_name);

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1054,7 +1054,6 @@ int main(int argc, char** argv) {
     if (dirp) {
         while ((dir = readdir(dirp)) != NULL) {
           //fprintf(stderr,"In temp folder: %s\n",dir->d_name);
-          regcomp(&regex,"^[ICM+]",0);
           regcomp(&regex,"\\+",0);
 
           if (!regexec(&regex,dir->d_name,(size_t) 0,NULL,0)) {

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1395,6 +1395,7 @@ void process_trickle(double current_cpu_time,const char* wu_name,const char* res
           fclose(trickle_file);
        }
     }
+    delete [] trickle;
 }
 
 // Check whether a file exists

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1061,6 +1061,7 @@ int main(int argc, char** argv) {
             fprintf(stderr,"Adding to the zip: %s\n",(temp_path+std::string("/")+dir->d_name).c_str());
           }
         }
+        regfree(&regex);
         closedir(dirp);
     }
 

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
     std::string ifsdata_file, ic_ancil_file, climate_data_file, horiz_resolution, vert_resolution, grid_type;
     std::string project_path, result_name, wu_name, version, tmpstr1, tmpstr2, tmpstr3;
     std::string ifs_line="", iter="0", ifs_word="", second_part, upload_file_name, last_line="";
+    std::string upfile("");
     int upload_interval, timestep_interval, ICM_file_interval, process_status, retval=0, i, j;
     int restart_interval, current_iter=0, count=0, trickle_upload_count;
     char strTmp[_MAX_PATH], upload_file[_MAX_PATH], result_base_name[64];
@@ -834,7 +835,9 @@ int main(int argc, char** argv) {
                       std::sprintf(upload_file,"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
 
                       fprintf(stderr,"Zipping up the intermediate file: %s\n",upload_file);
-                      retval = boinc_zip(ZIP_IT,upload_file,&zfl);
+                      upfile = string(upload_file);
+                      retval = boinc_zip(ZIP_IT,upfile,&zfl);  // n.b. pass std::string to avoid copy-on-call
+                      upfile.clear();
 
                       if (retval) {
                          fprintf(stderr,"..Zipping up the intermediate file failed\n");
@@ -880,7 +883,9 @@ int main(int argc, char** argv) {
                    memset(upload_file, 0x00, sizeof(upload_file));
                    std::sprintf(upload_file,"%s%s",project_path.c_str(),upload_file_name.c_str());
                    if (zfl.size() > 0){
-                      retval = boinc_zip(ZIP_IT,upload_file,&zfl);
+                      upfile = string(upload_file);
+                      retval = boinc_zip(ZIP_IT,upfile,&zfl);
+                      upfile.clear();
 
                       if (retval) {
                          fprintf(stderr,"..Creating the zipped upload file failed\n");
@@ -1074,7 +1079,9 @@ int main(int argc, char** argv) {
           std::sprintf(upload_file,"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
 
           fprintf(stderr,"Zipping up the final file: %s\n",upload_file);
-          retval = boinc_zip(ZIP_IT,upload_file,&zfl);
+          upfile = string(upload_file);
+          retval = boinc_zip(ZIP_IT,upfile,&zfl);
+          upfile.clear();
 
           if (retval) {
              fprintf(stderr,"..Zipping up the final file failed\n");
@@ -1115,7 +1122,9 @@ int main(int argc, char** argv) {
        memset(upload_file, 0x00, sizeof(upload_file));
        std::sprintf(upload_file,"%s%s",project_path.c_str(),upload_file_name.c_str());
        if (zfl.size() > 0){
-          retval = boinc_zip(ZIP_IT,upload_file,&zfl);
+          upfile = string(upload_file);
+          retval = boinc_zip(ZIP_IT,upfile,&zfl);
+          upfile.clear();
           if (retval) {
              fprintf(stderr,"..Creating the zipped upload file failed\n");
              boinc_end_critical_section();


### PR DESCRIPTION
Fixed leaks in:
1/ process_trickle
2/ regcomp calls.
3/ boinc_zip()

Please see issue gdcarver/openifs#20 for full description.