### PR TITLE
Some security fixes, refactor code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@
 #
 #       Glenn 
 
-VERSION = 1.08
-TARGET  = openifs_$(VERSION)_x86_64-pc-linux-gnu
-DEBUG   = openifs_$(VERSION)_x86_64-pc-linux-gnu-debug
+VERSION = 43r3_1.00
+TARGET  = oifs_$(VERSION)_x86_64-pc-linux-gnu
+DEBUG   = oifs_$(VERSION)_x86_64-pc-linux-gnu-debug
 SRC     = openifs.cpp
 
 CC       = g++

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -63,7 +63,8 @@ int main(int argc, char** argv) {
     std::string project_path, result_name, wu_name, version, tmpstr1, tmpstr2, tmpstr3;
     std::string ifs_line="", iter="0", ifs_word="", second_part, upload_file_name, last_line="";
     std::string upfile("");
-    int upload_interval, timestep_interval, ICM_file_interval, process_status, retval=0, i, j;
+    int upload_interval, timestep_interval, ICM_file_interval, retval=0, i, j;
+    int process_status=1;
     int restart_interval, current_iter=0, count=0, trickle_upload_count;
     char strTmp[_MAX_PATH], upload_file[_MAX_PATH], result_base_name[64];
     char *pathvar;

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -974,7 +974,9 @@ int main(int argc, char** argv) {
        ifs_word="";
        oifs_parse_ifsstat(ifs_stat_file,ifs_word,3);
        if (ifs_word!="CNT0") {
+         cerr << "CNT0 not found; string returned was: " << ifs_word << '\n';
          // print extra files to help diagnose fail
+         print_last_lines("ifs.stat",8);
          print_last_lines("rcf",11);              // openifs restart control
          print_last_lines("waminfo",17);          // wave model restart control
          print_last_lines(progress_file,8);

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -871,12 +871,12 @@ int main(int argc, char** argv) {
                          fprintf(stderr,"Finished the upload of the intermediate file: %s\n",upload_file_name.c_str());
                       }
 		      
-		                trickle_upload_count++;
-		                if (trickle_upload_count == 10) {
+                      trickle_upload_count++;
+                      if (trickle_upload_count == 10) {
                         // Produce trickle
                         process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
-		                  trickle_upload_count = 0;
-		                }
+                        trickle_upload_count = 0;
+                      }
                    }
                    last_upload = current_iter; 
                 }
@@ -917,11 +917,11 @@ int main(int argc, char** argv) {
                    last_upload = current_iter;
 		
                    trickle_upload_count++;
-		             if (trickle_upload_count == 10) {
+                   if (trickle_upload_count == 10) {
                       // Produce trickle
                       process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
-		                trickle_upload_count = 0;
-		             }
+                      trickle_upload_count = 0;
+                   }
 
                 }
                 boinc_end_critical_section();

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -708,7 +708,7 @@ int main(int argc, char** argv) {
           iter = last_iter;
           if( file_exists(slot_path + std::string("/ifs.stat")) ) {
 
-             //  To reduce I/O, open file once only and use get_parse_ifsstat() to parse the step count
+             //  To reduce I/O, open file once only and use oifs_parse_ifsstat() to parse the step count
              if( !(ifs_stat_file.is_open()) ) {
                 ifs_stat_file.open(slot_path + std::string("/ifs.stat"));
              } 

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -66,13 +66,13 @@ int main(int argc, char** argv) {
     int upload_interval, timestep_interval, ICM_file_interval, process_status, retval=0, i, j;
     int restart_interval, current_iter=0, count=0, trickle_upload_count;
     char strTmp[_MAX_PATH], upload_file[_MAX_PATH], result_base_name[64];
-    char *pathvar;
+    char *pathvar=NULL;
     long handleProcess;
     double tv_sec, tv_usec, fraction_done, current_cpu_time=0, total_nsteps = 0;
     struct dirent *dir;
     struct rusage usage;
     regex_t regex;
-    DIR *dirp;
+    DIR *dirp=NULL;
     ZipFileList zfl;
     std::ifstream ifs_stat_file;
 	
@@ -1307,7 +1307,7 @@ long launch_process(const char* slot_path,const char* strCmd,const char* exptid,
           break;
        }
        case 0: { //The child process
-          char *pathvar;
+          char *pathvar=NULL;
           // Set the GRIB_SAMPLES_PATH environmental variable
           std::string GRIB_SAMPLES_var = std::string("GRIB_SAMPLES_PATH=") + slot_path + \
                                          std::string("/eccodes/ifs_samples/grib1_mlgrib2");

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -917,11 +917,11 @@ int main(int argc, char** argv) {
                    last_upload = current_iter;
 		
                    trickle_upload_count++;
-		   if (trickle_upload_count == 10) {
+		             if (trickle_upload_count == 10) {
                       // Produce trickle
                       process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
-		      trickle_upload_count = 0;
-		   }
+		                trickle_upload_count = 0;
+		             }
 
                 }
                 boinc_end_critical_section();
@@ -957,8 +957,8 @@ int main(int argc, char** argv) {
      
 
       if (!boinc_is_standalone()) {
-	 // If the current iteration is at a restart iteration     
-	 if (!(std::stoi(iter)%restart_interval)) restart_cpu_time = current_cpu_time;
+	     // If the current iteration is at a restart iteration     
+	     if (!(std::stoi(iter)%restart_interval)) restart_cpu_time = current_cpu_time;
 	      
          // Provide the current cpu_time to the BOINC server (note: this is deprecated in BOINC)
          boinc_report_app_status(current_cpu_time,restart_cpu_time,fraction_done);
@@ -969,10 +969,10 @@ int main(int argc, char** argv) {
 	  
          // Check the status of the client if not in standalone mode     
          process_status = check_boinc_status(handleProcess,process_status);
-       }
+      }
 	
-       // Check the status of the child process    
-       process_status = check_child_status(handleProcess,process_status);
+      // Check the status of the child process    
+      process_status = check_child_status(handleProcess,process_status);
     }
 
 

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -836,8 +836,12 @@ int main(int argc, char** argv) {
                    if (zfl.size() > 0){
 
                       // Create the zipped upload file from the list of files added to zfl
+                      int rsize;
                       memset(upload_file, 0x00, sizeof(upload_file));
-                      std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+                      rsize = std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+                      if ( rsize >= (int)sizeof(upload_file) || rsize < 0) {                   // rsize ignores NULL terminating string
+                        cerr << "... Warning. upload_file string overrun prevented. Return value: " << rsize << '\n';
+                      }
 
                       fprintf(stderr,"Zipping up the intermediate file: %s\n",upload_file);
                       upfile = string(upload_file);
@@ -885,8 +889,13 @@ int main(int argc, char** argv) {
                    fprintf(stderr,"The current upload_file_name is: %s\n",upload_file_name.c_str());
 
                    // Create the zipped upload file from the list of files added to zfl
+                   int rsize;
                    memset(upload_file, 0x00, sizeof(upload_file));
-                   std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
+                   rsize = std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
+                   if ( rsize >= (int)sizeof(upload_file) || rsize < 0) {
+                     cerr << "... Warning. upload_file stdalone string overrun prevented. Return value: " << rsize << '\n';
+                   }
+
                    if (zfl.size() > 0){
                       upfile = string(upload_file);
                       retval = boinc_zip(ZIP_IT,upfile,&zfl);
@@ -1083,8 +1092,12 @@ int main(int argc, char** argv) {
        if (zfl.size() > 0){
 
           // Create the zipped upload file from the list of files added to zfl
+          int rsize;
           memset(upload_file, 0x00, sizeof(upload_file));
-          std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+          rsize = std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+          if ( rsize >= (int)sizeof(upload_file) || rsize < 0 ) {
+             cerr << "... Warning. final upload_file string overrun prevented. Return value: " << rsize << '\n';
+          }
 
           fprintf(stderr,"Zipping up the final file: %s\n",upload_file);
           upfile = string(upload_file);
@@ -1127,8 +1140,12 @@ int main(int argc, char** argv) {
        fprintf(stderr,"The final upload_file_name is: %s\n",upload_file_name.c_str());
 
        // Create the zipped upload file from the list of files added to zfl
+       int rsize;
        memset(upload_file, 0x00, sizeof(upload_file));
-       std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
+       rsize = std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
+       if ( rsize >= (int)sizeof(upload_file) || rsize < 0 ) {
+          cerr << "... Warning. final upload_file stdalone string overrun prevented. Return value: " << rsize << '\n';
+       }
        if (zfl.size() > 0){
           upfile = string(upload_file);
           retval = boinc_zip(ZIP_IT,upfile,&zfl);
@@ -1366,6 +1383,7 @@ std::string get_tag(const std::string &filename) {
 // Produce the trickle and either upload to the project server or as a physical file
 void process_trickle(double current_cpu_time,const char* wu_name,const char* result_name,const char* slot_path,int timestep) {
     char trickle[_MAX_PATH];
+    int rsize;
 
     //fprintf(stderr,"current_cpu_time: %f\n",current_cpu_time);
     //fprintf(stderr,"wu_name: %s\n",wu_name);
@@ -1373,8 +1391,11 @@ void process_trickle(double current_cpu_time,const char* wu_name,const char* res
     //fprintf(stderr,"slot_path: %s\n",slot_path);
     //fprintf(stderr,"timestep: %d\n",timestep);
 
-    std::snprintf(trickle,sizeof(trickle), "<wu>%s</wu>\n<result>%s</result>\n<ph></ph>\n<ts>%d</ts>\n<cp>%ld</cp>\n<vr></vr>\n",\
+    rsize = std::snprintf(trickle,sizeof(trickle), "<wu>%s</wu>\n<result>%s</result>\n<ph></ph>\n<ts>%d</ts>\n<cp>%ld</cp>\n<vr></vr>\n",\
                            wu_name,result_name, timestep,(long) current_cpu_time);
+    if ( rsize >= (int)sizeof(trickle) || rsize < 0 ) {
+       cerr << "... Warning. trickle string overrun prevented. Return value: " << rsize << '\n';
+    }
     //fprintf(stderr,"Contents of trickle: %s\n",trickle);
 
     // Upload the trickle if not in standalone mode

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -837,7 +837,7 @@ int main(int argc, char** argv) {
 
                       // Create the zipped upload file from the list of files added to zfl
                       memset(upload_file, 0x00, sizeof(upload_file));
-                      std::sprintf(upload_file,"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+                      std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
 
                       fprintf(stderr,"Zipping up the intermediate file: %s\n",upload_file);
                       upfile = string(upload_file);
@@ -886,7 +886,7 @@ int main(int argc, char** argv) {
 
                    // Create the zipped upload file from the list of files added to zfl
                    memset(upload_file, 0x00, sizeof(upload_file));
-                   std::sprintf(upload_file,"%s%s",project_path.c_str(),upload_file_name.c_str());
+                   std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
                    if (zfl.size() > 0){
                       upfile = string(upload_file);
                       retval = boinc_zip(ZIP_IT,upfile,&zfl);
@@ -1084,7 +1084,7 @@ int main(int argc, char** argv) {
 
           // Create the zipped upload file from the list of files added to zfl
           memset(upload_file, 0x00, sizeof(upload_file));
-          std::sprintf(upload_file,"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
+          std::snprintf(upload_file,sizeof(upload_file),"%s%s_%d.zip",project_path.c_str(),result_base_name,upload_file_number);
 
           fprintf(stderr,"Zipping up the final file: %s\n",upload_file);
           upfile = string(upload_file);
@@ -1128,7 +1128,7 @@ int main(int argc, char** argv) {
 
        // Create the zipped upload file from the list of files added to zfl
        memset(upload_file, 0x00, sizeof(upload_file));
-       std::sprintf(upload_file,"%s%s",project_path.c_str(),upload_file_name.c_str());
+       std::snprintf(upload_file,sizeof(upload_file),"%s%s",project_path.c_str(),upload_file_name.c_str());
        if (zfl.size() > 0){
           upfile = string(upload_file);
           retval = boinc_zip(ZIP_IT,upfile,&zfl);
@@ -1365,7 +1365,7 @@ std::string get_tag(const std::string &filename) {
 
 // Produce the trickle and either upload to the project server or as a physical file
 void process_trickle(double current_cpu_time,const char* wu_name,const char* result_name,const char* slot_path,int timestep) {
-    char* trickle = new char[512];
+    char trickle[_MAX_PATH];
 
     //fprintf(stderr,"current_cpu_time: %f\n",current_cpu_time);
     //fprintf(stderr,"wu_name: %s\n",wu_name);
@@ -1373,7 +1373,7 @@ void process_trickle(double current_cpu_time,const char* wu_name,const char* res
     //fprintf(stderr,"slot_path: %s\n",slot_path);
     //fprintf(stderr,"timestep: %d\n",timestep);
 
-    std::sprintf(trickle, "<wu>%s</wu>\n<result>%s</result>\n<ph></ph>\n<ts>%d</ts>\n<cp>%ld</cp>\n<vr></vr>\n",\
+    std::snprintf(trickle,sizeof(trickle), "<wu>%s</wu>\n<result>%s</result>\n<ph></ph>\n<ts>%d</ts>\n<cp>%ld</cp>\n<vr></vr>\n",\
                            wu_name,result_name, timestep,(long) current_cpu_time);
     //fprintf(stderr,"Contents of trickle: %s\n",trickle);
 
@@ -1386,18 +1386,16 @@ void process_trickle(double current_cpu_time,const char* wu_name,const char* res
 
     // Write out the trickle in standalone mode
     else {
-       char trickle_name[_MAX_PATH];
-       std::sprintf(trickle_name,"%s/trickle_%lu.xml",slot_path,(unsigned long) time(NULL));
+       std::snprintf(trickle,sizeof(trickle),"%s/trickle_%lu.xml",slot_path,(unsigned long) time(NULL));
 
-       fprintf(stderr,"Writing trickle to: %s\n",trickle_name);
+       fprintf(stderr,"Writing trickle to: %s\n",trickle);
 
-       FILE* trickle_file = boinc_fopen(trickle_name,"w");
+       FILE* trickle_file = boinc_fopen(trickle,"w");
        if (trickle_file) {
           fwrite(trickle, 1, strlen(trickle), trickle_file);
           fclose(trickle_file);
        }
     }
-    delete [] trickle;
 }
 
 // Check whether a file exists

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1151,31 +1151,16 @@ int main(int argc, char** argv) {
     if (process_status == 1){
       boinc_end_critical_section();
       boinc_finish(0);
-      #ifdef __APPLE_CC__
-         _exit(0);
-      #else
-         exit(0);
-      #endif 
       return 0;
     }
     else if (process_status == 2){
       boinc_end_critical_section();
       boinc_finish(0);
-      #ifdef __APPLE_CC__
-         _exit(0);
-      #else
-         exit(0);
-      #endif 
       return 0;
     }
     else {
       boinc_end_critical_section();
       boinc_finish(1);
-      #ifdef __APPLE_CC__
-         _exit(1);
-      #else
-         exit(1);
-      #endif 
       return 1;
     }	
 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -975,7 +975,7 @@ int main(int argc, char** argv) {
        ifs_word="";
        oifs_parse_ifsstat(ifs_stat_file,ifs_word,3);
        if (ifs_word!="CNT0") {
-         cerr << "CNT0 not found; string returned was: " << ifs_word << '\n';
+         cerr << "CNT0 not found; string returned was: " << "'" << ifs_word << "'" << '\n';
          // print extra files to help diagnose fail
          print_last_lines("ifs.stat",8);
          print_last_lines("rcf",11);              // openifs restart control

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -867,12 +867,12 @@ int main(int argc, char** argv) {
                          fprintf(stderr,"Finished the upload of the intermediate file: %s\n",upload_file_name.c_str());
                       }
 		      
-		      trickle_upload_count++;
-		      if (trickle_upload_count == 10) {
+		                trickle_upload_count++;
+		                if (trickle_upload_count == 10) {
                         // Produce trickle
                         process_trickle(current_cpu_time,wu_name.c_str(),result_base_name,slot_path,current_iter);
-		        trickle_upload_count = 0;
-		      }
+		                  trickle_upload_count = 0;
+		                }
                    }
                    last_upload = current_iter; 
                 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1608,7 +1608,6 @@ bool oifs_get_stat(std::ifstream& ifs_stat, std::string& logline) {
     string             statline = "";         // default: 4th element of ifs.stat file lines
     static string      current_line = "";
     static streamoff   p = 0;             // stream offset position
-    bool               updated=false;
 
     if ( !ifs_stat.is_open() ) {
         cerr << "oifs_get_stat: Error. ifs.stat file is not open" << endl;
@@ -1619,9 +1618,7 @@ bool oifs_get_stat(std::ifstream& ifs_stat, std::string& logline) {
 
     ifs_stat.seekg(p);
     while ( std::getline(ifs_stat, statline) ) {
-      //cerr << "oifs_get_stat statline = " << statline << endl;
       current_line = statline;
-      updated = true;
 
       if ( ifs_stat.tellg() == -1 )     // set p to eof for next call to this fn
          p = p + statline.size();
@@ -1631,7 +1628,7 @@ bool oifs_get_stat(std::ifstream& ifs_stat, std::string& logline) {
     ifs_stat.clear();           // must clear stream error before attempting to read again as file remains open
 
     logline = current_line;
-    //cerr << "oifs_get_stat: updated? " << updated << " : current_line= " << current_line << '\n';
+
     return true;
 }
 


### PR DESCRIPTION
Andy,

Changes in brief (will send an email with more details) and one outstanding question (below):

1/  All char* pointer variables are now initialized to NULL in their declarations for security.

2/  process_status is now initalized to 1 when declared. On the slim chance it might not be initialized under the if statement, its next use would be otherwise undefined.

3/  refactored oifs_parse_ifsstat. More tests showed this didn't always work at the end of the run due to a timing issue depending when the model wrote & control code read, the last line. Have split this routine into two functions to read & parse the line. Tested ok.

4/ removed the exit() statements after call to boinc_finish(). exit() in C++ does not guarantee to close files nor release memory associated with local objects.  I kept getting tasks that worked fine but the client would fail them with an error code. It had to be something to do with exit() as that's the next statement after boinc_finish().

C++ exit() does not work the same as exit() under C. I read up on this. There is plenty of discussion on stack-exchange if you're interested.

=> at end of main(), for process_status=2, the return code is 0, but I think this should be 1 as status=2 is an abort which means the model won't have finished?  Something to discuss.
