### PR TITLE
replace endl with non-flushing \n and remove fflush calls. 

### DIFF
--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1210,24 +1210,24 @@ int check_child_status(long handleProcess, int process_status) {
        // Child exited normally but model might still have failed
        if (WIFEXITED(stat)) {
           process_status = 1;
-          cerr << "..The child process terminated with status: " << WEXITSTATUS(stat) << endl;
+          cerr << "..The child process terminated with status: " << WEXITSTATUS(stat) << '\n';
        }
        // Child process has exited due to signal that was not caught
        // n.b. OpenIFS has its own signal handler.
        else if (WIFSIGNALED(stat)) {
           process_status = 3;
-          cerr << "..The child process has been killed with signal: " << WTERMSIG(stat) << endl;
+          cerr << "..The child process has been killed with signal: " << WTERMSIG(stat) << '\n';
        }
        // Child is stopped
        else if (WIFSTOPPED(stat)) {
           process_status = 4;
-          cerr << "..The child process has stopped with signal: " << WSTOPSIG(stat) << endl;
+          cerr << "..The child process has stopped with signal: " << WSTOPSIG(stat) << '\n';
        }
     }
     else if ( pid == -1) {
       // should not get here, it means the child could not be found
       process_status = 5;
-      cerr << "Unable to retrieve status of child process " << endl;
+      cerr << "Unable to retrieve status of child process " << '\n';
       perror("waitpid() error");
     }
     return process_status;
@@ -1241,21 +1241,18 @@ int check_boinc_status(long handleProcess, int process_status) {
     // If a quit, abort or no heartbeat has been received from the BOINC client, end child process
     if (status.quit_request) {
        fprintf(stderr,"Quit request received from BOINC client, ending the child process\n");
-       fflush(stderr);
        kill(handleProcess,SIGKILL);
        process_status = 2;
        return process_status;
     }
     else if (status.abort_request) {
        fprintf(stderr,"Abort request received from BOINC client, ending the child process\n");
-       fflush(stderr);
        kill(handleProcess,SIGKILL);
        process_status = 1;
        return process_status;
     }
     else if (status.no_heartbeat) {
        fprintf(stderr,"No heartbeat received from BOINC client, ending the child process\n");
-       fflush(stderr);
        kill(handleProcess,SIGKILL);
        process_status = 1;
        return process_status;
@@ -1264,28 +1261,24 @@ int check_boinc_status(long handleProcess, int process_status) {
     else {
        if (status.suspended) {
           fprintf(stderr,"Suspend request received from the BOINC client, suspending the child process\n");
-          fflush(stderr);
           kill(handleProcess,SIGSTOP);
 
           while (status.suspended) {
              boinc_get_status(&status);
              if (status.quit_request) {
                 fprintf(stderr,"Quit request received from the BOINC client, ending the child process\n");
-                fflush(stderr);
                 kill(handleProcess,SIGKILL);
                 process_status = 2;
                 return process_status;
              }
              else if (status.abort_request) {
                 fprintf(stderr,"Abort request received from the BOINC client, ending the child process\n");
-                fflush(stderr);
                 kill(handleProcess,SIGKILL);
                 process_status = 1;
                 return process_status;
              }
              else if (status.no_heartbeat) {
                 fprintf(stderr,"No heartbeat received from the BOINC client, ending the child process\n");
-                fflush(stderr);
                 kill(handleProcess,SIGKILL);
                 process_status = 1;
                 return process_status;
@@ -1294,7 +1287,6 @@ int check_boinc_status(long handleProcess, int process_status) {
           }
           // Resume child process
           fprintf(stderr,"Resuming the child process\n");
-          fflush(stderr);
           kill(handleProcess,SIGCONT);
           process_status = 0;
        }


### PR DESCRIPTION
Use of 'endl' in check_child_status() has been found to hang due to a file lock on stderr. It is possible this is because the model's process status has just been collected in the waitpid() call and closing it's files; one of which will be its stderr buffer as the model also writes to stderr as does the control code. I suspect the model locks stderr briefly to flush its buffer and that blocks the control code from writing the status message in check_child_status().

The fix is to replace endl with a normal '\n'.   Also removed fflush(stderr) in check_client_status in case a similar situation there arises. 

I noticed one task on my machine had been hung for 3 hrs. The model had completed it's final step according to ifs.stat, but stderr.txt did not have the 'process has exited message', so had not reached that part of the code in check_child_status. I attached the gdb debugger to the process and was able to get a trace-back (see below) which indicated the control code was stuck in the flush(stderr) coming from the cerr << .... << endl;   output line. process_status was = 1.

It's also possible there is some interaction with the client on the use of stderr, rather than the model. But I could not see any flush call when attaching gdb to the client process.

gdb instructions & output for reference:

```
#Modify ptrace permissions
#(see https://www.kernel.org/doc/Documentation/security/Yama.txt)

echo 0 | tee  /proc/sys/kernel/yama/ptrace_scope

root@bader:/work/boinc-client/slots/0# gdb
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word".
(gdb) attach 740305
Attaching to process 740305
[New LWP 740306]
[New LWP 740307]
__lll_lock_wait_private (futex=0x722920 <_IO_stdfile_1_lock>) at lowlevellock.c:35
35      lowlevellock.c: No such file or directory.
(gdb) bt
#0  __lll_lock_wait_private (futex=0x722920 <_IO_stdfile_1_lock>) at lowlevellock.c:35
#1  0x0000000000577226 in fflush ()
#2  0x00000000004d6793 in std::ostream::flush() ()
#3  0x00000000004d6ff0 in std::ostream::sentry::sentry(std::ostream&) ()
#4  0x00000000004d76ab in std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) ()
#5  0x00000000004d7b7c in std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*) ()
#6  0x0000000000415083 in check_child_status (handleProcess=740313, process_status=1) at openifs.cpp:1196
#7  0x000000000040f8cc in main (argc=9, argv=0x7fffd2637b98) at openifs.cpp:966
(gdb)
```


