### PR TITLE
Fix use of strings in control code

### DIFF
--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1380,7 +1380,7 @@ void process_trickle(double current_cpu_time, std::string wu_name, std::string r
     if (!boinc_is_standalone()) {
        std::string variety("orig");
        cerr << "Uploading trickle at timestep: " << timestep << '\n';
-       boinc_send_trickle_up(variety.data(), const_cast<char*> (trickle.c_str()));
+       boinc_send_trickle_up(variety.data(), trickle.data());
     }
 
     // Write out the trickle in standalone mode

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -249,7 +249,7 @@ int main(int argc, char** argv) {
 	
     // Parse the fort.4 namelist for the filenames and variables
     std::string namelist_file = slot_path + std::string("/") + namelist;
-    std::string namelist_line="", nss="", delimiter="=";
+    std::string namelist_line="", delimiter="=";
     std::ifstream namelist_filestream;
 
    // Check for the existence of the namelist

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -94,19 +94,19 @@ int main(int argc, char** argv) {
 
     retval = boinc_init_options(&options);
     if (retval) {
-       cerr << "..BOINC init options failed" << "\n";
+       cerr << "..BOINC init options failed" << '\n';
        return retval;
     }
 
-    cerr << "(argv0) " << argv[0] << "\n";
-    cerr << "(argv1) start_date: " << argv[1] << "\n";
-    cerr << "(argv2) exptid: " << argv[2] << "\n";
-    cerr << "(argv3) unique_member_id: " << argv[3] << "\n";
-    cerr << "(argv4) batchid: " << argv[4] << "\n";
-    cerr << "(argv5) wuid: " << argv[5] << "\n";
-    cerr << "(argv6) fclen: " << argv[6] << "\n";
-    cerr << "(argv7) app_name: " << argv[7] << "\n";
-    cerr << "(argv8) nthreads: " << argv[8] << "\n";
+    cerr << "(argv0) " << argv[0] << '\n';
+    cerr << "(argv1) start_date: " << argv[1] << '\n';
+    cerr << "(argv2) exptid: " << argv[2] << '\n';
+    cerr << "(argv3) unique_member_id: " << argv[3] << '\n';
+    cerr << "(argv4) batchid: " << argv[4] << '\n';
+    cerr << "(argv5) wuid: " << argv[5] << '\n';
+    cerr << "(argv6) fclen: " << argv[6] << '\n';
+    cerr << "(argv7) app_name: " << argv[7] << '\n';
+    cerr << "(argv8) nthreads: " << argv[8] << '\n';
 
     // Read the exptid, batchid, version, wuid from the command line
     std::string start_date = argv[1]; // simulation start date
@@ -127,51 +127,51 @@ int main(int argc, char** argv) {
     // Get the slots path (the current working path)
     std::string slot_path = std::filesystem::current_path();
     if (slot_path == "") {
-      cerr << "..current_path() returned empty" << "\n";
+      cerr << "..current_path() returned empty" << '\n';
     }
     else {
-      cerr << "Working directory is: "<< slot_path << "\n";      
+      cerr << "Working directory is: "<< slot_path << '\n';      
     }
 
     if (!boinc_is_standalone()) {
 
       // Get the project path
       project_path = dataBOINC.project_dir + std::string("/");
-      cerr << "Project directory is: " << project_path << "\n";
+      cerr << "Project directory is: " << project_path << '\n';
 	    
       // Get the app version and re-parse to add a dot
       version = std::to_string(dataBOINC.app_version);
       if (version.length()==2) {
          version = version.insert(0,".");
-         //cerr << "version: " << version << "\n";
+         //cerr << "version: " << version << '\n';
       }
       else if (version.length()==3) {
          version = version.insert(1,".");
-         //cerr << "version: " << version << "\n";
+         //cerr << "version: " << version << '\n';
       }
       else if (version.length()==4) {
          version = version.insert(2,".");
-         //cerr << "version: " << version << "\n";
+         //cerr << "version: " << version << '\n';
       }
       else {
-         cerr << "..Error with the length of app_version, length is: " << version.length() << "\n";
+         cerr << "..Error with the length of app_version, length is: " << version.length() << '\n';
          return 1;
       }
 	    
-      cerr << "app name: " << app_name << "\n";
-      cerr << "version: " << version << "\n";
+      cerr << "app name: " << app_name << '\n';
+      cerr << "version: " << version << '\n';
     }
     // Running in standalone
     else {
-      cerr << "Running in standalone mode" << "\n";
+      cerr << "Running in standalone mode" << '\n';
       // Set the project path
       project_path = slot_path + std::string("/../projects/");
-      cerr << "Project directory is: " << project_path << "\n";
+      cerr << "Project directory is: " << project_path << '\n';
 	    
       // In standalone get the app version from the command line
       version = argv[9];
-      cerr << "app name: " << app_name << "\n"; 
-      cerr << "(argv9) app_version: " << argv[9] << "\n"; 
+      cerr << "app name: " << app_name << '\n'; 
+      cerr << "(argv9) app_version: " << argv[9] << '\n'; 
     }
 
     boinc_begin_critical_section();
@@ -179,8 +179,8 @@ int main(int argc, char** argv) {
     // Create temporary folder for moving the results to and uploading the results from
     // BOINC measures the disk usage on the slots directory so we must move all results out of this folder
     std::string temp_path = project_path + app_name + std::string("_") + wuid;
-    cerr << "Location of temp folder: " << temp_path << "\n";
-    if (mkdir(temp_path.c_str(),S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH) != 0) cerr << "..mkdir for temp folder for results failed" << "\n";
+    cerr << "Location of temp folder: " << temp_path << '\n';
+    if (mkdir(temp_path.c_str(),S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH) != 0) cerr << "..mkdir for temp folder for results failed" << '\n';
 
     // macOS
     #if defined (__APPLE__)
@@ -196,20 +196,20 @@ int main(int argc, char** argv) {
     // Copy the app file to the working directory
     std::string app_source = project_path + app_file;
     std::string app_destination = slot_path + std::string("/") + app_file;
-    cerr << "Copying: " << app_source << " to: " << app_destination << "\n";
+    cerr << "Copying: " << app_source << " to: " << app_destination << '\n';
     retval = boinc_copy(app_source.c_str(), app_destination.c_str());
     if (retval) {
-       cerr << "..Copying the app file to the working directory failed: error " << retval << "\n";
+       cerr << "..Copying the app file to the working directory failed: error " << retval << '\n';
        return retval;
     }
 
     // Unzip the app zip file
     std::string app_zip = slot_path + std::string("/") + app_file;
-    cerr << "Unzipping the app zip file: " << app_zip << "\n";
+    cerr << "Unzipping the app zip file: " << app_zip << '\n';
     retval = boinc_zip(UNZIP_IT, app_zip.c_str(), slot_path);
 
     if (retval) {
-       cerr << "..Unzipping the app file failed" << "\n";
+       cerr << "..Unzipping the app file failed" << '\n';
        return retval;
     }
     // Remove the zip file
@@ -227,18 +227,18 @@ int main(int argc, char** argv) {
 
     // Copy the namelist files to the working directory
     std::string wu_destination = namelist_zip;
-    cerr << "Copying the namelist files from: " << wu_source << " to: " << wu_destination << "\n";
+    cerr << "Copying the namelist files from: " << wu_source << " to: " << wu_destination << '\n';
     retval = boinc_copy(wu_source.c_str(), wu_destination.c_str());
     if (retval) {
-       cerr << "..Copying the namelist files to the working directory failed" << "\n";
+       cerr << "..Copying the namelist files to the working directory failed" << '\n';
        return retval;
     }
 
     // Unzip the namelist zip file
-    cerr << "Unzipping the namelist zip file: " << namelist_zip << "\n";
+    cerr << "Unzipping the namelist zip file: " << namelist_zip << '\n';
     retval = boinc_zip(UNZIP_IT, namelist_zip.c_str(), slot_path);
     if (retval) {
-       cerr << "..Unzipping the namelist file failed" << "\n";
+       cerr << "..Unzipping the namelist file failed" << '\n';
        return retval;
     }
     // Remove the zip file
@@ -254,7 +254,7 @@ int main(int argc, char** argv) {
 
    // Check for the existence of the namelist
    if( !file_exists(namelist_file) ) {
-      cerr << "..The namelist file does not exist: " << namelist_file << "\n";
+      cerr << "..The namelist file does not exist: " << namelist_file << '\n';
       return 1;        // should terminate, the model won't run.
     }
 
@@ -271,44 +271,44 @@ int main(int argc, char** argv) {
           ifsdata_file = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           ifsdata_file.erase(std::remove(ifsdata_file.begin(), ifsdata_file.end(), ' '), ifsdata_file.end());
-          cerr << "ifsdata_file: " << ifsdata_file << "\n";
+          cerr << "ifsdata_file: " << ifsdata_file << '\n';
        }
        else if (nss.str().find("IC_ANCIL_FILE") != std::string::npos) {
           ic_ancil_file = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           ic_ancil_file.erase(std::remove(ic_ancil_file.begin(), ic_ancil_file.end(), ' '), ic_ancil_file.end());
-          cerr << "ic_ancil_file: " << ic_ancil_file << "\n"; 
+          cerr << "ic_ancil_file: " << ic_ancil_file << '\n'; 
        }
        else if (nss.str().find("CLIMATE_DATA_FILE") != std::string::npos) {
           climate_data_file = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           climate_data_file.erase(std::remove(climate_data_file.begin(),climate_data_file.end(),' '), climate_data_file.end());
-          cerr << "climate_data_file: " << climate_data_file << "\n";
+          cerr << "climate_data_file: " << climate_data_file << '\n';
        }
        else if (nss.str().find("HORIZ_RESOLUTION") != std::string::npos) {
           horiz_resolution = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           horiz_resolution.erase(std::remove(horiz_resolution.begin(),horiz_resolution.end(),' '), horiz_resolution.end());
-          cerr << "horiz_resolution: " << horiz_resolution << "\n";
+          cerr << "horiz_resolution: " << horiz_resolution << '\n';
        }
        else if (nss.str().find("VERT_RESOLUTION") != std::string::npos) {
           vert_resolution = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           vert_resolution.erase(std::remove(vert_resolution.begin(), vert_resolution.end(), ' '), vert_resolution.end());
-          cerr << "vert_resolution: " << vert_resolution << "\n";
+          cerr << "vert_resolution: " << vert_resolution << '\n';
        }
        else if (nss.str().find("GRID_TYPE") != std::string::npos) {
           grid_type = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           grid_type.erase(std::remove(grid_type.begin(), grid_type.end(),' '), grid_type.end());
-          cerr << "grid_type: " << grid_type << "\n";
+          cerr << "grid_type: " << grid_type << '\n';
        }
        else if (nss.str().find("UPLOAD_INTERVAL") != std::string::npos) {
           tmpstr1 = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
           // Remove any whitespace
           tmpstr1.erase(std::remove(tmpstr1.begin(), tmpstr1.end(),' '), tmpstr1.end());
           upload_interval=std::stoi(tmpstr1);
-          cerr << "upload_interval: " << upload_interval << "\n";
+          cerr << "upload_interval: " << upload_interval << '\n';
        }
        else if (nss.str().find("UTSTEP") != std::string::npos) {
           tmpstr2 = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
@@ -316,7 +316,7 @@ int main(int argc, char** argv) {
 	  tmpstr2.erase(std::remove(tmpstr2.begin(), tmpstr2.end(),','), tmpstr2.end());
           tmpstr2.erase(std::remove(tmpstr2.begin(), tmpstr2.end(),' '), tmpstr2.end());
           timestep_interval = std::stoi(tmpstr2);
-          cerr << "utstep: " << timestep_interval << "\n";
+          cerr << "utstep: " << timestep_interval << '\n';
        }
        else if (nss.str().find("!NFRPOS") != std::string::npos) {
           tmpstr3 = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
@@ -324,7 +324,7 @@ int main(int argc, char** argv) {
           tmpstr3.erase(std::remove(tmpstr3.begin(), tmpstr3.end(),','), tmpstr3.end());
           tmpstr3.erase(std::remove(tmpstr3.begin(), tmpstr3.end(),' '), tmpstr3.end());
           ICM_file_interval = std::stoi(tmpstr3);
-          cerr << "nfrpos: " << ICM_file_interval << "\n";
+          cerr << "nfrpos: " << ICM_file_interval << '\n';
        }
        else if (nss.str().find("NFRRES") != std::string::npos) {     // frequency of model output: +ve steps, -ve in hours.
           tmpstr3 = nss.str().substr(nss.str().find(delimiter)+1, nss.str().length()-1);
@@ -334,7 +334,7 @@ int main(int argc, char** argv) {
           if ( check_stoi(tmpstr3) ) {
             restart_interval = stoi(tmpstr3);
           } else {
-            cerr << "..Warning, unable to read restart interval, setting to zero, got string: " << tmpstr3 << "\n";
+            cerr << "..Warning, unable to read restart interval, setting to zero, got string: " << tmpstr3 << '\n';
             restart_interval = 0;
           }
        }
@@ -343,7 +343,7 @@ int main(int argc, char** argv) {
 
     // restart frequency might be in units of hrs, convert to model steps
     if ( restart_interval < 0 )   restart_interval = abs(restart_interval)*3600 / timestep_interval;
-    cerr << "nfrres: restart dump frequency (steps) " << restart_interval << "\n";
+    cerr << "nfrres: restart dump frequency (steps) " << restart_interval << '\n';
 
     // this should match CUSTEP in fort.4. If it doesn't we have a problem
     total_nsteps = (num_days * 86400.0) / (double) timestep_interval;
@@ -359,18 +359,18 @@ int main(int argc, char** argv) {
 
     // Copy the IC ancils to working directory
     std::string ic_ancil_destination = ic_ancil_zip;
-    cerr << "Copying IC ancils from: " << ic_ancil_source << " to: " << ic_ancil_destination << "\n";
+    cerr << "Copying IC ancils from: " << ic_ancil_source << " to: " << ic_ancil_destination << '\n';
     retval = boinc_copy(ic_ancil_source.c_str(), ic_ancil_destination.c_str());
     if (retval) {
-       cerr << "..Copying the IC ancils to the working directory failed" << "\n";
+       cerr << "..Copying the IC ancils to the working directory failed" << '\n';
        return retval;
     }
 
     // Unzip the IC ancils zip file
-    cerr << "Unzipping the IC ancils zip file: " << ic_ancil_zip << "\n";
+    cerr << "Unzipping the IC ancils zip file: " << ic_ancil_zip << '\n';
     retval = boinc_zip(UNZIP_IT, ic_ancil_zip.c_str(), slot_path);
     if (retval) {
-       cerr << "..Unzipping the IC ancils file failed" << "\n";
+       cerr << "..Unzipping the IC ancils file failed" << '\n';
        return retval;
     }
     // Remove the zip file
@@ -382,26 +382,26 @@ int main(int argc, char** argv) {
     // Process the ifsdata_file:
     // Make the ifsdata directory
     std::string ifsdata_folder = slot_path + std::string("/ifsdata");
-    if (mkdir(ifsdata_folder.c_str(),S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH) != 0) cerr << "..mkdir for ifsdata folder failed" << "\n";
+    if (mkdir(ifsdata_folder.c_str(),S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH) != 0) cerr << "..mkdir for ifsdata folder failed" << '\n';
 
     // Get the name of the 'jf_' filename from a link within the ifsdata_file
     std::string ifsdata_source = get_tag(slot_path + std::string("/") + ifsdata_file + std::string(".zip"));
 
     // Copy the ifsdata_file to the working directory
     std::string ifsdata_destination = ifsdata_folder + std::string("/") + ifsdata_file + std::string(".zip");
-    cerr << "Copying the ifsdata_file from: " << ifsdata_source << " to: " << ifsdata_destination << "\n";
+    cerr << "Copying the ifsdata_file from: " << ifsdata_source << " to: " << ifsdata_destination << '\n';
     retval = boinc_copy(ifsdata_source.c_str(), ifsdata_destination.c_str());
     if (retval) {
-       cerr << "..Copying the ifsdata file to the working directory failed" << "\n";
+       cerr << "..Copying the ifsdata file to the working directory failed" << '\n';
        return retval;
     }
 
     // Unzip the ifsdata_file zip file
     std::string ifsdata_zip = ifsdata_folder + std::string("/") + ifsdata_file + std::string(".zip");
-    cerr << "Unzipping the ifsdata_zip file: " << ifsdata_zip << "\n";
+    cerr << "Unzipping the ifsdata_zip file: " << ifsdata_zip << '\n';
     retval = boinc_zip(UNZIP_IT, ifsdata_zip.c_str(), ifsdata_folder + std::string("/"));
     if (retval) {
-       cerr << "..Unzipping the ifsdata_zip file failed" << "\n";
+       cerr << "..Unzipping the ifsdata_zip file failed" << '\n';
        return retval;
     }
     // Remove the zip file
@@ -414,26 +414,26 @@ int main(int argc, char** argv) {
     // Make the climate data directory
     std::string climate_data_path = slot_path + std::string("/") + horiz_resolution + grid_type;
     if (mkdir(climate_data_path.c_str(),S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH) != 0) \
-                       cerr << "..mkdir for the climate data folder failed" << "\n";
+                       cerr << "..mkdir for the climate data folder failed" << '\n';
 
     // Get the name of the 'jf_' filename from a link within the climate_data_file
     std::string climate_data_source = get_tag(slot_path + std::string("/") + climate_data_file + std::string(".zip"));
 
     // Copy the climate data file to working directory
     std::string climate_data_destination = climate_data_path + std::string("/") + climate_data_file + std::string(".zip");
-    cerr << "Copying the climate data file from: " << climate_data_source << " to: " << climate_data_destination << "\n";
+    cerr << "Copying the climate data file from: " << climate_data_source << " to: " << climate_data_destination << '\n';
     retval = boinc_copy(climate_data_source.c_str(), climate_data_destination.c_str());
     if (retval) {
-       cerr << "..Copying the climate data file to the working directory failed" << "\n";
+       cerr << "..Copying the climate data file to the working directory failed" << '\n';
        return retval;
     }	
 
     // Unzip the climate data zip file
     std::string climate_zip = climate_data_destination;
-    cerr << "Unzipping the climate data zip file: " << climate_zip << "\n";
+    cerr << "Unzipping the climate data zip file: " << climate_zip << '\n';
     retval = boinc_zip(UNZIP_IT, climate_zip.c_str(), climate_data_path);
     if (retval) {
-       cerr << "..Unzipping the climate data file failed" << "\n";
+       cerr << "..Unzipping the climate data file failed" << '\n';
        return retval;
     }
     // Remove the zip file
@@ -447,106 +447,106 @@ int main(int argc, char** argv) {
     // Possible values are: 'quiet', 'verbose' or 'abort'
     std::string OIFS_var("OIFS_DUMMY_ACTION=abort");
     if (putenv((char *)OIFS_var.c_str())) {
-      cerr << "..Setting the OIFS_DUMMY_ACTION environmental variable failed" << "\n";
+      cerr << "..Setting the OIFS_DUMMY_ACTION environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("OIFS_DUMMY_ACTION");
-    //cerr << "The OIFS_DUMMY_ACTION environmental variable is: " << pathvar << "\n";
+    //cerr << "The OIFS_DUMMY_ACTION environmental variable is: " << pathvar << '\n';
 
     // Set the OMP_NUM_THREADS environmental variable, the number of threads
     std::string OMP_NUM_var = std::string("OMP_NUM_THREADS=") + nthreads;
     if (putenv((char *)OMP_NUM_var.c_str())) {
-      cerr << "..Setting the OMP_NUM_THREADS environmental variable failed" << "\n";
+      cerr << "..Setting the OMP_NUM_THREADS environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("OMP_NUM_THREADS");
-    //cerr << "The OMP_NUM_THREADS environmental variable is: " << pathvar << "\n";
+    //cerr << "The OMP_NUM_THREADS environmental variable is: " << pathvar << '\n';
 
     // Set the OMP_SCHEDULE environmental variable, this enforces static thread scheduling
     std::string OMP_SCHED_var("OMP_SCHEDULE=STATIC");
     if (putenv((char *)OMP_SCHED_var.c_str())) {
-      cerr << "..Setting the OMP_SCHEDULE environmental variable failed" << "\n";
+      cerr << "..Setting the OMP_SCHEDULE environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("OMP_SCHEDULE");
-    //cerr << "The OMP_SCHEDULE environmental variable is: " << pathvar << "\n";
+    //cerr << "The OMP_SCHEDULE environmental variable is: " << pathvar << '\n';
 
     // Set the DR_HOOK environmental variable, this controls the tracing facility in OpenIFS, off=0 and on=1
     std::string DR_HOOK_var("DR_HOOK=1");
     if (putenv((char *)DR_HOOK_var.c_str())) {
-      cerr << "..Setting the DR_HOOK environmental variable failed" << "\n";
+      cerr << "..Setting the DR_HOOK environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("DR_HOOK");
-    //cerr << "The DR_HOOK environmental variable is: " << pathvar << "\n";
+    //cerr << "The DR_HOOK environmental variable is: " << pathvar << '\n';
 
     // Set the DR_HOOK_HEAPCHECK environmental variable, this ensures the heap size statistics are reported
     std::string DR_HOOK_HEAP_var("DR_HOOK_HEAPCHECK=no");
     if (putenv((char *)DR_HOOK_HEAP_var.c_str())) {
-      cerr << "..Setting the DR_HOOK_HEAPCHECK environmental variable failed" << "\n";
+      cerr << "..Setting the DR_HOOK_HEAPCHECK environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("DR_HOOK_HEAPCHECK");
-    //cerr << "The DR_HOOK_HEAPCHECK environmental variable is: " << pathvar << "\n";
+    //cerr << "The DR_HOOK_HEAPCHECK environmental variable is: " << pathvar << '\n';
 
     // Set the DR_HOOK_STACKCHECK environmental variable, this ensures the stack size statistics are reported
     std::string DR_HOOK_STACK_var("DR_HOOK_STACKCHECK=no");
     if (putenv((char *)DR_HOOK_STACK_var.c_str())) {
-      cerr << "..Setting the DR_HOOK_STACKCHECK environmental variable failed" << "\n";
+      cerr << "..Setting the DR_HOOK_STACKCHECK environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("DR_HOOK_STACKCHECK");
-    //cerr << "The DR_HOOK_STACKCHECK environmental variable is: " << pathvar << "\n";
+    //cerr << "The DR_HOOK_STACKCHECK environmental variable is: " << pathvar << '\n';
 	
     // Set the EC_MEMINFO environment variable, only applies to OpenIFS 43r3.
     // Disable EC_MEMINFO to remove the useless EC_MEMINFO messages to the stdout file to reduce filesize.
     std::string EC_MEMINFO("EC_MEMINFO=0");
     if (putenv((char *)EC_MEMINFO.c_str())) {
-       cerr << "..Setting the EC_MEMINFO environment variable failed" << "\n";
+       cerr << "..Setting the EC_MEMINFO environment variable failed" << '\n';
        return 1;
     }
     pathvar = getenv("EC_MEMINFO");
-    //cerr << "The EC_MEMINFO environment variable is: " << pathvar << "\n";
+    //cerr << "The EC_MEMINFO environment variable is: " << pathvar << '\n';
 
     // Disable Heap memory stats at end of run; does not work for CPDN version of OpenIFS
     std::string EC_PROFILE_HEAP("EC_PROFILE_HEAP=0");
     if (putenv((char *)EC_PROFILE_HEAP.c_str())) {
-       cerr << "..Setting the EC_PROFILE_HEAP environment variable failed" << "\n";
+       cerr << "..Setting the EC_PROFILE_HEAP environment variable failed" << '\n';
        return 1;
     }
     pathvar = getenv("EC_PROFILE_HEAP");
-    //cerr << "The EC_PROFILE_HEAP environment variable is: " << pathvar << "\n";
+    //cerr << "The EC_PROFILE_HEAP environment variable is: " << pathvar << '\n';
 
     // Disable all memory stats at end of run; does not work for CPDN version of OpenIFS
     std::string EC_PROFILE_MEM("EC_PROFILE_MEM=0");
     if (putenv((char *)EC_PROFILE_MEM.c_str())) {
-       cerr << "..Setting the EC_PROFILE_MEM environment variable failed" << "\n";
+       cerr << "..Setting the EC_PROFILE_MEM environment variable failed" << '\n';
        return 1;
     }
     pathvar = getenv("EC_PROFILE_MEM");
-    //cerr << "The EC_PROFILE_MEM environment variable is: " << pathvar << "\n";
+    //cerr << "The EC_PROFILE_MEM environment variable is: " << pathvar << '\n';
 
     // Set the OMP_STACKSIZE environmental variable, OpenIFS needs more stack memory per process
     std::string OMP_STACK_var("OMP_STACKSIZE=128M");
     if (putenv((char *)OMP_STACK_var.c_str())) {
-      cerr << "..Setting the OMP_STACKSIZE environmental variable failed" << "\n";
+      cerr << "..Setting the OMP_STACKSIZE environmental variable failed" << '\n';
       return 1;
     }
     pathvar = getenv("OMP_STACKSIZE");
-    //cerr << "The OMP_STACKSIZE environmental variable is: " << pathvar << "\n";
+    //cerr << "The OMP_STACKSIZE environmental variable is: " << pathvar << '\n';
 
 
     // Set the core dump size to 0
     struct rlimit core_limits;
     core_limits.rlim_cur = core_limits.rlim_max = 0;
-    if (setrlimit(RLIMIT_CORE, &core_limits) != 0) cerr << "..Setting the core dump size to 0 failed" << "\n";
+    if (setrlimit(RLIMIT_CORE, &core_limits) != 0) cerr << "..Setting the core dump size to 0 failed" << '\n';
 
     // Set the stack limit to be unlimited
     struct rlimit stack_limits;
     // In macOS we cannot set the stack size limit to infinity
     #ifndef __APPLE__ // Linux
        stack_limits.rlim_cur = stack_limits.rlim_max = RLIM_INFINITY;
-       if (setrlimit(RLIMIT_STACK, &stack_limits) != 0) cerr << "..Setting the stack limit to unlimited failed" << "\n";
+       if (setrlimit(RLIMIT_STACK, &stack_limits) != 0) cerr << "..Setting the stack limit to unlimited failed" << '\n';
     #endif
 
     int last_cpu_time, restart_cpu_time = 0, upload_file_number, last_upload, model_completed, restart_iter;
@@ -559,7 +559,7 @@ int main(int argc, char** argv) {
 	
     // Model progress is held in the progress file
     // First check if a file is not already present from an unscheduled shutdown
-    cerr << "Checking for progress XML file: " << progress_file << "\n";
+    cerr << "Checking for progress XML file: " << progress_file << '\n';
 
     if ( file_exists(progress_file) && !file_is_empty(progress_file) ) {
        std::ifstream progress_file_in(progress_file);
@@ -568,7 +568,7 @@ int main(int argc, char** argv) {
 
        // If present parse file and extract values
        progress_file_in.open(progress_file);
-       cerr << "Opened progress file ok : " << progress_file << "\n";
+       cerr << "Opened progress file ok : " << progress_file << '\n';
        progress_file_buffer << progress_file_in.rdbuf();
        progress_file_in.close();
 	    
@@ -612,7 +612,7 @@ int main(int argc, char** argv) {
 	    
     // Write out the new progress file. Note this truncates progress_file to zero bytes if it already exists (as in a model restart)
     std::ofstream progress_file_out(progress_file);
-    cerr << "Creating progress file: " << progress_file << "\n";
+    cerr << "Creating progress file: " << progress_file << '\n';
 
     progress_file_out.open(progress_file);
     progress_file_out <<"<?xml version=\"1.0\" encoding=\"utf-8\"?>"<< '\n';
@@ -625,11 +625,11 @@ int main(int argc, char** argv) {
     progress_file_out <<"</running_values>"<< std::endl;
     progress_file_out.close();
 
-    cerr << "last_cpu_time: " << last_cpu_time << "\n";
-    cerr << "upload_file_number: " << upload_file_number << "\n";
-    cerr << "last_iter: " << last_iter << "\n";
-    cerr << "last_upload: " << last_upload << "\n";
-    cerr << "model_completed: " << model_completed << "\n";
+    cerr << "last_cpu_time: " << last_cpu_time << '\n';
+    cerr << "upload_file_number: " << upload_file_number << '\n';
+    cerr << "last_iter: " << last_iter << '\n';
+    cerr << "last_upload: " << last_upload << '\n';
+    cerr << "model_completed: " << model_completed << '\n';
 
 
     fraction_done = 0;
@@ -638,16 +638,16 @@ int main(int argc, char** argv) {
     // seconds between upload files: upload_interval
     // seconds between ICM files: ICM_file_interval * timestep_interval
     // upload interval in steps = upload_interval / timestep_interval
-    //cerr "upload_interval: "<< upload_interval << ", timestep_interval: " << timestep_interval << "\n";
+    //cerr "upload_interval: "<< upload_interval << ", timestep_interval: " << timestep_interval << '\n';
 
     // Check if upload_interval x timestep_interval equal to zero
     if (upload_interval * timestep_interval == 0) {
-       cerr << "..upload_interval x timestep_interval equals zero" << "\n";
+       cerr << "..upload_interval x timestep_interval equals zero" << '\n';
        return 1;
     }
 
     int total_length_of_simulation = (int) (num_days * 86400);
-    cerr << "total_length_of_simulation: " << total_length_of_simulation << "\n";
+    cerr << "total_length_of_simulation: " << total_length_of_simulation << '\n';
 
     // Get result_base_name to construct upload file names using 
     // the first upload as an example and then stripping off '_0.zip'
@@ -655,7 +655,7 @@ int main(int argc, char** argv) {
     if (!boinc_is_standalone()) {
        retval = boinc_resolve_filename_s("upload_file_0.zip", resolved_name);
        if (retval) {
-          cerr << "..boinc_resolve_filename failed" << "\n";      // should we return at this point?
+          cerr << "..boinc_resolve_filename failed" << '\n';      // should we return at this point?
        }
 
        result_base_name = std::filesystem::path(resolved_name).stem();     // returns filename without path nor '.zip'
@@ -663,9 +663,9 @@ int main(int argc, char** argv) {
           result_base_name.erase(resolved_name.length()-2);                   // removes the '_0'
        }
 
-       cerr << "result_base_name: " << result_base_name << "\n";
+       cerr << "result_base_name: " << result_base_name << '\n';
        if (result_base_name.compare("upload_file") == 0) {
-          cerr << "..Failed to get result name" << "\n";
+          cerr << "..Failed to get result name" << '\n';
           return 1;
        }
     }
@@ -677,7 +677,7 @@ int main(int argc, char** argv) {
        // If exists then run file
        FILE* pipe = popen(override_env_vars.c_str(), "r");
        if (!pipe) {
-          cerr << "..Failed to open environment variables override file" << "\n";
+          cerr << "..Failed to open environment variables override file" << '\n';
           return 1;
        }
        pclose(pipe);
@@ -741,11 +741,11 @@ int main(int argc, char** argv) {
 
              // Move the ICMGG result file to the temporary folder in the project directory
              if(file_exists(slot_path + std::string("/ICMGG") + second_part)) {
-                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMGG") + second_part) << "\n";
+                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMGG") + second_part) << '\n';
                 retval = boinc_copy((slot_path + std::string("/ICMGG") + second_part).c_str() , \
                                     (temp_path + std::string("/ICMGG") + second_part).c_str());
                 if (retval) {
-                   cerr << "..Copying ICMGG result file to the temp folder in the projects directory failed" << "\n";
+                   cerr << "..Copying ICMGG result file to the temp folder in the projects directory failed" << '\n';
                    return retval;
                 }
                 // If result file has been successfully copied over, remove it from slots directory
@@ -756,11 +756,11 @@ int main(int argc, char** argv) {
 
              // Move the ICMSH result file to the temporary folder in the project directory
              if(file_exists(slot_path+std::string("/ICMSH") + second_part)) {
-                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMSH") + second_part) << "\n";
+                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMSH") + second_part) << '\n';
                 retval = boinc_copy((slot_path + std::string("/ICMSH") + second_part).c_str() , \
                                     (temp_path + std::string("/ICMSH") + second_part).c_str());
                 if (retval) {
-                   cerr << "..Copying ICMSH result file to the temp folder in the projects directory failed" << "\n";
+                   cerr << "..Copying ICMSH result file to the temp folder in the projects directory failed" << '\n';
                    return retval;
                 }
                 // If result file has been successfully copied over, remove it from slots directory
@@ -771,11 +771,11 @@ int main(int argc, char** argv) {
 
              // Move the ICMUA result file to the temporary folder in the project directory (this is for 43r3 and above only)
              if(file_exists(slot_path+std::string("/ICMUA") + second_part)) {
-                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMUA") + second_part) << "\n";
+                cerr << "Moving to projects directory: " << (slot_path + std::string("/ICMUA") + second_part) << '\n';
                 retval = boinc_copy((slot_path+std::string("/ICMUA") + second_part).c_str() , \
                                     (temp_path+std::string("/ICMUA") + second_part).c_str());
                 if (retval) {
-                   cerr << "..Copying ICMUA result file to the temp folder in the projects directory failed" << "\n";
+                   cerr << "..Copying ICMUA result file to the temp folder in the projects directory failed" << '\n';
                    return retval;
                 }
                 // If result file has been successfully copied over, remove it from slots directory
@@ -787,10 +787,10 @@ int main(int argc, char** argv) {
              // Convert iteration number to seconds
              current_iter = (std::stoi(last_iter)) * timestep_interval;
 
-             //cerr << "Current iteration of model: " << last_iter << "\n";
-             //cerr << "timestep_interval: " << timestep_interval << "\n";
-             //cerr << "current_iter: " << current_iter << "\n";
-             //cerr << "last_upload: " << last_upload << "\n";
+             //cerr << "Current iteration of model: " << last_iter << '\n';
+             //cerr << "timestep_interval: " << timestep_interval << '\n';
+             //cerr << "current_iter: " << current_iter << '\n';
+             //cerr << "last_upload: " << last_upload << '\n';
 
              // Upload a new upload file if the end of an upload_interval has been reached
              if((( current_iter - last_upload ) >= (upload_interval * timestep_interval)) && (current_iter < total_length_of_simulation)) {
@@ -801,16 +801,16 @@ int main(int argc, char** argv) {
 
                 // Cycle through all the steps from the last upload to the current upload
                 for (i = (last_upload / timestep_interval); i < (current_iter / timestep_interval); i++) {
-                   //cerr << "last_upload/timestep_interval: " << (last_upload/timestep_interval) << "\n";
-                   //cerr << "current_iter/timestep_interval: " << (current_iter/timestep_interval) << "\n";
-                   //cerr << "i: " << (std::to_string(i)) << "\n";
+                   //cerr << "last_upload/timestep_interval: " << (last_upload/timestep_interval) << '\n';
+                   //cerr << "current_iter/timestep_interval: " << (current_iter/timestep_interval) << '\n';
+                   //cerr << "i: " << (std::to_string(i)) << '\n';
 
                    // Construct file name of the ICM result file
                    second_part = get_second_part(std::to_string(i), exptid);
 
                    // Add ICMGG result files to zip to be uploaded
                    if(file_exists(temp_path + std::string("/ICMGG") + second_part)) {
-                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMGG")+second_part) << "\n";
+                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMGG")+second_part) << '\n';
                       zfl.push_back(temp_path + std::string("/ICMGG") + second_part);
                       // Delete the file that has been added to the zip
                       // std::remove((temp_path+std::string("/ICMGG")+second_part).c_str());
@@ -818,7 +818,7 @@ int main(int argc, char** argv) {
 
                    // Add ICMSH result files to zip to be uploaded
                    if(file_exists(temp_path + std::string("/ICMSH") + second_part)) {
-                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMSH")+second_part) << "\n";
+                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMSH")+second_part) << '\n';
                       zfl.push_back(temp_path + std::string("/ICMSH") + second_part);
                       // Delete the file that has been added to the zip
                       // std::remove((temp_path+std::string("/ICMSH")+second_part).c_str());
@@ -826,7 +826,7 @@ int main(int argc, char** argv) {
 		
                    // Add ICMUA result files to zip to be uploaded
                    if(file_exists(temp_path + std::string("/ICMUA") + second_part)) {
-                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMUA")+second_part) << "\n";
+                      cerr << "Adding to the zip: " << (temp_path + std::string("/ICMUA")+second_part) << '\n';
                       zfl.push_back(temp_path + std::string("/ICMUA") + second_part);
                       // Delete the file that has been added to the zip
                       // std::remove((temp_path+std::string("/ICMUA")+second_part).c_str());
@@ -841,14 +841,14 @@ int main(int argc, char** argv) {
                       // Create the zipped upload file from the list of files added to zfl
                       upload_file = project_path + result_base_name + "_" + std::to_string(upload_file_number) + ".zip";
 
-                      cerr << "Zipping up the intermediate file: " << upload_file << "\n";
+                      cerr << "Zipping up the intermediate file: " << upload_file << '\n';
                       //upfile = string(upload_file);
                       upfile = upload_file;
                       retval = boinc_zip(ZIP_IT, upfile, &zfl);  // n.b. pass std::string to avoid copy-on-call
                       upfile.clear();
 
                       if (retval) {
-                         cerr << "..Zipping up the intermediate file failed" << "\n";
+                         cerr << "..Zipping up the intermediate file failed" << '\n';
                          boinc_end_critical_section();
                          return retval;
                       }
@@ -862,12 +862,12 @@ int main(int argc, char** argv) {
                    
                       // Upload the file. In BOINC the upload file is the logical name, not the physical name
                       upload_file_name = std::string("upload_file_") + std::to_string(upload_file_number) + std::string(".zip");
-                      cerr << "Uploading the intermediate file: " << upload_file_name << "\n";
+                      cerr << "Uploading the intermediate file: " << upload_file_name << '\n';
                       sleep_until(system_clock::now() + seconds(20));
                       boinc_upload_file(upload_file_name);
                       retval = boinc_upload_status(upload_file_name);
                       if (!retval) {
-                         cerr << "Finished the upload of the intermediate file: " << upload_file_name << "\n";
+                         cerr << "Finished the upload of the intermediate file: " << upload_file_name << '\n';
                       }
 		      
                       trickle_upload_count++;
@@ -885,7 +885,7 @@ int main(int argc, char** argv) {
                    upload_file_name = app_name + std::string("_") + unique_member_id + std::string("_") + start_date + std::string("_") + \
                                std::to_string(num_days_trunc) + std::string("_") + batchid + std::string("_") + wuid + std::string("_") + \
                                std::to_string(upload_file_number) + std::string(".zip");
-                   cerr << "The current upload_file_name is: " << upload_file_name << "\n";
+                   cerr << "The current upload_file_name is: " << upload_file_name << '\n';
 
                    // Create the zipped upload file from the list of files added to zfl
                    upload_file = project_path + upload_file_name;
@@ -897,7 +897,7 @@ int main(int argc, char** argv) {
                       upfile.clear();
 
                       if (retval) {
-                         cerr << "..Creating the zipped upload file failed" << "\n";
+                         cerr << "..Creating the zipped upload file failed" << '\n';
                          boinc_end_critical_section();
                          return retval;
                       }
@@ -1010,11 +1010,11 @@ int main(int argc, char** argv) {
 
     // Move the ICMGG result file to the temporary folder in the project directory
     if(file_exists(slot_path+std::string("/ICMGG") + second_part)) {
-       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMGG") + second_part) << "\n";
+       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMGG") + second_part) << '\n';
        retval = boinc_copy((slot_path + std::string("/ICMGG") + second_part).c_str() , \
                            (temp_path + std::string("/ICMGG") + second_part).c_str());
        if (retval) {
-          cerr << "..Copying ICMGG result file to the temp folder in the projects directory failed" << "\n";
+          cerr << "..Copying ICMGG result file to the temp folder in the projects directory failed" << '\n';
           return retval;
        }
        // If result file has been successfully copied over, remove it from slots directory
@@ -1025,11 +1025,11 @@ int main(int argc, char** argv) {
 
     // Move the ICMSH result file to the temporary folder in the project directory
     if(file_exists(slot_path+std::string("/ICMSH") + second_part)) {
-       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMSH") + second_part) << "\n";
+       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMSH") + second_part) << '\n';
        retval = boinc_copy((slot_path + std::string("/ICMSH") + second_part).c_str() , \
                            (temp_path + std::string("/ICMSH") + second_part).c_str());
        if (retval) {
-          cerr << "..Copying ICMSH result file to the temp folder in the projects directory failed" << "\n";
+          cerr << "..Copying ICMSH result file to the temp folder in the projects directory failed" << '\n';
           return retval;
        }
        // If result file has been successfully copied over, remove it from slots directory
@@ -1040,11 +1040,11 @@ int main(int argc, char** argv) {
 
     // Move the ICMUA result file to the temporary folder in the project directory (this is for 43r3 and above only)
     if(file_exists(slot_path + std::string("/ICMUA") + second_part)) {
-       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMUA") + second_part) << "\n";
+       cerr << "Moving to projects directory: " << (slot_path+std::string("/ICMUA") + second_part) << '\n';
        retval = boinc_copy((slot_path + std::string("/ICMUA") + second_part).c_str() , \
                            (temp_path + std::string("/ICMUA") + second_part).c_str());
        if (retval) {
-          cerr << "..Copying ICMUA result file to the temp folder in the projects directory failed" << "\n";
+          cerr << "..Copying ICMUA result file to the temp folder in the projects directory failed" << '\n';
 	  return retval;
        }
        // If result file has been successfully copied over, remove it from slots directory
@@ -1089,13 +1089,13 @@ int main(int argc, char** argv) {
           // Create the zipped upload file from the list of files added to zfl
           upload_file = project_path + result_base_name + "_" + std::to_string(upload_file_number) + ".zip";
 
-          cerr << "Zipping up the final file: " << upload_file << "\n";
+          cerr << "Zipping up the final file: " << upload_file << '\n';
           upfile = upload_file;
           retval = boinc_zip(ZIP_IT, upfile, &zfl);
           upfile.clear();
 
           if (retval) {
-             cerr << "..Zipping up the final file failed" << "\n";
+             cerr << "..Zipping up the final file failed" << '\n';
              boinc_end_critical_section();
              return retval;
           }
@@ -1109,12 +1109,12 @@ int main(int argc, char** argv) {
 
           // Upload the file. In BOINC the upload file is the logical name, not the physical name
           upload_file_name = std::string("upload_file_") + std::to_string(upload_file_number) + std::string(".zip");
-          cerr << "Uploading the final file: " << upload_file_name << "\n";
+          cerr << "Uploading the final file: " << upload_file_name << '\n';
           sleep_until(system_clock::now() + seconds(20));
           boinc_upload_file(upload_file_name);
           retval = boinc_upload_status(upload_file_name);
           if (!retval) {
-             cerr << "Finished the upload of the final file" << "\n";
+             cerr << "Finished the upload of the final file" << '\n';
           }
 	       
 	  // Produce trickle
@@ -1127,7 +1127,7 @@ int main(int argc, char** argv) {
        upload_file_name = app_name + std::string("_") + unique_member_id + std::string("_") + start_date + std::string("_") + \
                    std::to_string(num_days_trunc) + std::string("_") + batchid + std::string("_") + wuid + std::string("_") + \
                    std::to_string(upload_file_number) + std::string(".zip");
-       cerr << "The final upload_file_name is: " << upload_file_name << "\n";
+       cerr << "The final upload_file_name is: " << upload_file_name << '\n';
 
        // Create the zipped upload file from the list of files added to zfl
        upload_file = project_path + upload_file_name;
@@ -1137,7 +1137,7 @@ int main(int argc, char** argv) {
           retval = boinc_zip(ZIP_IT,upfile,&zfl);
           upfile.clear();
           if (retval) {
-             cerr << "..Creating the zipped upload file failed" << "\n";
+             cerr << "..Creating the zipped upload file failed" << '\n';
              boinc_end_critical_section();
              return retval;
           }
@@ -1275,7 +1275,7 @@ int check_boinc_status(long handleProcess, int process_status) {
              sleep_until(system_clock::now() + seconds(1));
           }
           // Resume child process
-          cerr << "Resuming the child process" << "\n";
+          cerr << "Resuming the child process" << '\n';
           kill(handleProcess, SIGCONT);
           process_status = 0;
        }
@@ -1287,13 +1287,13 @@ long launch_process(const std::string slot_path,const char* strCmd,const char* e
     int retval = 0;
     long handleProcess;
 
-    //cerr << "slot_path: " << slot_path << "\n";
-    //cerr << "strCmd: " << strCmd << "\n";
-    //cerr << "exptid: " << exptid << "\n";
+    //cerr << "slot_path: " << slot_path << '\n';
+    //cerr << "strCmd: " << strCmd << '\n';
+    //cerr << "exptid: " << exptid << '\n';
 
     switch((handleProcess=fork())) {
        case -1: {
-          cerr << "..Unable to start a new child process" << "\n";
+          cerr << "..Unable to start a new child process" << '\n';
           exit(0);
           break;
        }
@@ -1303,36 +1303,36 @@ long launch_process(const std::string slot_path,const char* strCmd,const char* e
           std::string GRIB_SAMPLES_var = std::string("GRIB_SAMPLES_PATH=") + slot_path + \
                                          std::string("/eccodes/ifs_samples/grib1_mlgrib2");
           if (putenv((char *)GRIB_SAMPLES_var.c_str())) {
-            cerr << "..Setting the GRIB_SAMPLES_PATH failed" << "\n";
+            cerr << "..Setting the GRIB_SAMPLES_PATH failed" << '\n';
           }
           pathvar = getenv("GRIB_SAMPLES_PATH");
-          cerr << "The GRIB_SAMPLES_PATH environmental variable is: " << pathvar << "\n";
+          cerr << "The GRIB_SAMPLES_PATH environmental variable is: " << pathvar << '\n';
 
           // Set the GRIB_DEFINITION_PATH environmental variable
           std::string GRIB_DEF_var = std::string("GRIB_DEFINITION_PATH=") + slot_path + \
                                      std::string("/eccodes/definitions");
           if (putenv((char *)GRIB_DEF_var.c_str())) {
-            cerr << "..Setting the GRIB_DEFINITION_PATH failed" << "\n";
+            cerr << "..Setting the GRIB_DEFINITION_PATH failed" << '\n';
           }
           pathvar = getenv("GRIB_DEFINITION_PATH");
-          cerr << "The GRIB_DEFINITION_PATH environmental variable is: " << pathvar << "\n";
+          cerr << "The GRIB_DEFINITION_PATH environmental variable is: " << pathvar << '\n';
 
           if((app_name=="openifs") || (app_name=="oifs_40r1")) { // OpenIFS 40r1
-            cerr << "Executing the command: " << strCmd << " -e " << exptid << "\n";
+            cerr << "Executing the command: " << strCmd << " -e " << exptid << '\n';
             retval = execl(strCmd,strCmd,"-e",exptid,NULL);
           }
           else {  // OpenIFS 43r3 and above
-            cerr << "Executing the command: " << strCmd << "\n";
+            cerr << "Executing the command: " << strCmd << '\n';
             retval = execl(strCmd,strCmd,NULL,NULL,NULL);
           }
 
           // If execl returns then there was an error
-          cerr << "..The execl() command failed slot_path=" << slot_path << ",strCmd=" << strCmd << ",exptid=" << exptid << "\n";
+          cerr << "..The execl() command failed slot_path=" << slot_path << ",strCmd=" << strCmd << ",exptid=" << exptid << '\n';
           exit(retval);
           break;
        }
        default: 
-          cerr << "The child process has been launched with process id: " << handleProcess << "\n";
+          cerr << "The child process has been launched with process id: " << handleProcess << '\n';
     }
     return handleProcess;
 }
@@ -1364,31 +1364,31 @@ void process_trickle(double current_cpu_time, std::string wu_name, std::string r
     std::string trickle, trickle_location;
     int rsize;
 
-    //cerr << "current_cpu_time: " << current_cpu_time << "\n";
-    //cerr << "wu_name: " << wu_name << "\n";
-    //cerr << "result_base_name: " << result_base_name << "\n";
-    //cerr << "slot_path: " << slot_path << "\n";
-    //cerr << "timestep: " << timestep << "\n";
+    //cerr << "current_cpu_time: " << current_cpu_time << '\n';
+    //cerr << "wu_name: " << wu_name << '\n';
+    //cerr << "result_base_name: " << result_base_name << '\n';
+    //cerr << "slot_path: " << slot_path << '\n';
+    //cerr << "timestep: " << timestep << '\n';
 
     std::stringstream trickle_buffer;
     trickle_buffer << "<wu>" << wu_name << "</wu>\n<result>" << result_base_name << "</result>\n<ph></ph>\n<ts>" \
                    << timestep << "</ts>\n<cp>" << current_cpu_time << "</cp>\n<vr></vr>\n";
     trickle = trickle_buffer.str();
-    cerr << "Contents of trickle: " << trickle << "\n";
+    cerr << "Contents of trickle: " << trickle << '\n';
       
     // Upload the trickle if not in standalone mode
     if (!boinc_is_standalone()) {
        std::string variety("orig");
-       cerr << "Uploading trickle at timestep: " << timestep << "\n";
+       cerr << "Uploading trickle at timestep: " << timestep << '\n';
        boinc_send_trickle_up(variety.data(), const_cast<char*> (trickle.c_str()));
     }
 
     // Write out the trickle in standalone mode
     else {
        std::stringstream trickle_location_buffer;
-       trickle_location_buffer << slot_path << "/trickle_" << time(NULL) << ".xml" << "\n";
+       trickle_location_buffer << slot_path << "/trickle_" << time(NULL) << ".xml" << '\n';
        trickle_location = trickle_location_buffer.str();
-       cerr << "Writing trickle to: " << trickle_location << "\n";
+       cerr << "Writing trickle to: " << trickle_location << '\n';
        FILE* trickle_file = boinc_fopen(trickle_location.c_str(), "w");
        if (trickle_file) {
           fwrite(trickle.c_str(), 1, strlen(trickle.c_str()), trickle_file);
@@ -1520,7 +1520,7 @@ bool check_stoi(std::string& cin) {
     int step;
 
     if (std::any_of(cin.begin(), cin.end(), ::isalpha)) {
-        cerr << "Invalid characters in stoi string: " << cin << "\n";
+        cerr << "Invalid characters in stoi string: " << cin << '\n';
         return false;
     }
 
@@ -1528,15 +1528,15 @@ bool check_stoi(std::string& cin) {
     //  n.b. still need to check step <= max_step
     try {
         step = std::stoi(cin);
-        //cerr << "step converted is : " << step << "\n";
+        //cerr << "step converted is : " << step << '\n';
         return true;
     }
     catch (const std::invalid_argument &excep) {
-        cerr << "Invalid input argument for stoi : " << excep.what() << "\n";
+        cerr << "Invalid input argument for stoi : " << excep.what() << '\n';
         return false;
     }
     catch (const std::out_of_range &excep) {
-        cerr << "Out of range value for stoi : " << excep.what() << "\n";
+        cerr << "Out of range value for stoi : " << excep.what() << '\n';
         return false;
     }
 }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1386,12 +1386,12 @@ void process_trickle(double current_cpu_time, std::string wu_name, std::string r
     // Write out the trickle in standalone mode
     else {
        std::stringstream trickle_location_buffer;
-       trickle_location_buffer << slot_path << "/trickle_" << time(NULL) << ".xml" << '\n';
+       trickle_location_buffer << slot_path << "/trickle_" << time(NULL) << ".xml";
        trickle_location = trickle_location_buffer.str();
        cerr << "Writing trickle to: " << trickle_location << '\n';
        FILE* trickle_file = boinc_fopen(trickle_location.c_str(), "w");
        if (trickle_file) {
-          fwrite(trickle.c_str(), 1, strlen(trickle.c_str()), trickle_file);
+          fwrite(trickle.c_str(), 1, trickle.length(), trickle_file);
           fclose(trickle_file);
        }
     }

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -1374,7 +1374,7 @@ void process_trickle(double current_cpu_time, std::string wu_name, std::string r
     trickle_buffer << "<wu>" << wu_name << "</wu>\n<result>" << result_base_name << "</result>\n<ph></ph>\n<ts>" \
                    << timestep << "</ts>\n<cp>" << current_cpu_time << "</cp>\n<vr></vr>\n";
     trickle = trickle_buffer.str();
-    cerr << "Contents of trickle: " << trickle << '\n';
+    cerr << "Contents of trickle:\n" << trickle << '\n';
       
     // Upload the trickle if not in standalone mode
     if (!boinc_is_standalone()) {

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -659,8 +659,8 @@ int main(int argc, char** argv) {
        }
 
        result_base_name = std::filesystem::path(resolved_name).stem();     // returns filename without path nor '.zip'
-       if ( resolved_name.length() > 2 ){
-          result_base_name.erase(resolved_name.length()-2);                   // removes the '_0'
+       if ( result_base_name.length() > 2 ){
+          result_base_name.erase(result_base_name.length()-2);                   // removes the '_0'
        }
 
        cerr << "result_base_name: " << result_base_name << '\n';

--- a/openifs.cpp
+++ b/openifs.cpp
@@ -651,16 +651,20 @@ int main(int argc, char** argv) {
 
     // Get result_base_name to construct upload file names using 
     // the first upload as an example and then stripping off '_0.zip'
+
     if (!boinc_is_standalone()) {
        retval = boinc_resolve_filename_s("upload_file_0.zip", resolved_name);
        if (retval) {
-          cerr << "..boinc_resolve_filename failed" << "\n";
+          cerr << "..boinc_resolve_filename failed" << "\n";      // should we return at this point?
        }
 
-       cerr << "resolved_name: " << resolved_name << "\n";
-       strncpy(const_cast<char*> (result_base_name.c_str()), strip_path(resolved_name.c_str()), strlen(strip_path(resolved_name.c_str()))-6);
+       result_base_name = std::filesystem::path(resolved_name).stem();     // returns filename without path nor '.zip'
+       if ( resolved_name.length() > 2 ){
+          result_base_name.erase(resolved_name.length()-2);                   // removes the '_0'
+       }
+
        cerr << "result_base_name: " << result_base_name << "\n";
-       if (strcmp(result_base_name.c_str(), "upload_file")==0) {
+       if (result_base_name.compare("upload_file") == 0) {
           cerr << "..Failed to get result name" << "\n";
           return 1;
        }


### PR DESCRIPTION
Number of fixes. Now works correctly both standalone and running 'live' under a client.

1/   replace "\n" with '\n' everywhere conversion to C++ style output was made.
2/   result_base_name was not assigned because strncpy does not work with C++ strings. Rewritten to use std::filesystem.
3/   remove unused std::string nss, which was shadowed by stringsteam var in while() loop.
4/   change const_cast<char*> (trickle.c_str()) to trickle.data() in boinc_trickle_up call as fn expects a char* not const char*.
5/   trickle filename in standalone mode has '\n' on end of filename.